### PR TITLE
Update src.js

### DIFF
--- a/commands/other/src.js
+++ b/commands/other/src.js
@@ -43,9 +43,20 @@ module.exports = class SpeedrunBasicCommand extends Command {
       const body = await response.json();
 
       if (body.data.length === 0) {
-        message.say(
-          ':x: Error: ' + initial.data[0].names.international + ' has no runs.'
-        );
+        const gameNameArr = [];
+        initial.data.slice(0, 6).forEach(id => {
+          gameNameArr.push(id.names.international);
+        });
+        var gameName = new MessageEmbed()
+          .setColor('#3E8657')
+          .setTitle(':mag: Search Results')
+          .setThumbnail(initial.data[1].assets['cover-medium'].uri)
+          .addField('Try searching again with the following suggestions.', initial.data[0].names.international);
+        for (let i = 1; i < gameNameArr.length; i++) {
+          gameName.addField(`:video_game: Result ${i}`,gameNameArr[i],)
+        }
+        message.say(gameName)
+      
       } else {
         let platform =
           body.data[0].platforms.data.length > 0

--- a/commands/other/src.js
+++ b/commands/other/src.js
@@ -51,7 +51,9 @@ module.exports = class SpeedrunBasicCommand extends Command {
           .setColor('#3E8657')
           .setTitle(':mag: Search Results')
           .setThumbnail(initial.data[1].assets['cover-medium'].uri)
-          .addField('Try searching again with the following suggestions.', initial.data[0].names.international);
+          .addField('Try searching again with the following suggestions.', initial.data[0].names.international)
+          .setTimestamp()
+          .setFooter('Powered by www.speedrun.com', '');
         for (let i = 1; i < gameNameArr.length; i++) {
           gameName.addField(`:video_game: Result ${i}`,gameNameArr[i],)
         }

--- a/commands/other/src.js
+++ b/commands/other/src.js
@@ -33,7 +33,7 @@ module.exports = class SpeedrunBasicCommand extends Command {
 
     const initial = await respInitial.json();
     if (initial.data.length === 0) {
-      message.reply(':x: No game was found.');
+      message.say(':x: No game was found.');
     } else {
       let gameID = initial.data[0].id;
 
@@ -42,9 +42,9 @@ module.exports = class SpeedrunBasicCommand extends Command {
       );
       const body = await response.json();
 
-      if (body.data[0].runs.length === 0) {
-        message.reply(
-          body.data[0].game.data.names.international + ' has no runs'
+      if (body.data.length === 0) {
+        message.say(
+          ':x: Error: ' + initial.data[0].names.international + ' has no runs.'
         );
       } else {
         let platform =

--- a/commands/other/src.js
+++ b/commands/other/src.js
@@ -50,8 +50,8 @@ module.exports = class SpeedrunBasicCommand extends Command {
         var gameName = new MessageEmbed()
           .setColor('#3E8657')
           .setTitle(':mag: Search Results')
-          .setThumbnail(initial.data[1].assets['cover-medium'].uri)
-          .addField('Try searching again with the following suggestions.', initial.data[0].names.international)
+          .setThumbnail(initial.data[0].assets['cover-medium'].uri)
+          .addField(':x: Try searching again with the following suggestions.', initial.data[0].names.international + ` doesn't have any runs.`)
           .setTimestamp()
           .setFooter('Powered by www.speedrun.com', '');
         for (let i = 1; i < gameNameArr.length; i++) {


### PR DESCRIPTION
displays a Bot answer 
![SRC serch help](https://user-images.githubusercontent.com/12632936/97728932-23a46d00-1aa0-11eb-8fb6-3807a673e84a.PNG)



 Rather than a Technical error like ` TypeError: Cannot read property 'runs' of undefined
You shouldn't ever receive an error like this.`
Changed error to also deal with games that share names but are not released yet. like Battletoads and Double Dragon, Titles that are Retro (1991) and yet to be released (2020 , 2021) 
Should be a rare situation

Because most game titles that are cross platform are shared on a single leader board (Super Metroid Any% Category is shared with Wii, SNES, and PC emulator along with PAL/NTSC versions)  

and replaced the reply to say
felt like it was screaming at me LOL


I plan to make it work similarly to the `!play ` just a current place holder to button up the Technical error for a possible solution with the search 