### PR TITLE
Update musictrivia.json

### DIFF
--- a/resources/music/musictrivia.json
+++ b/resources/music/musictrivia.json
@@ -441,7 +441,7 @@
       "title": "Gasoline"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=VYOjWnS4cMY",
+      "url": "https://www.youtube.com/watch?v=VYOjWnS4cMY",
       "singer": "Childish Gambino",
       "title": "This Is America"
     },
@@ -766,12 +766,12 @@
       "title": "Raise your Glass"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=Nj2U6rhnucI",
+      "url": "https://www.youtube.com/watch?v=Nj2U6rhnucI",
       "singer": "dua lipa",
       "title": "break my heart"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=83xBPCw5hh4",
+      "url": "https://www.youtube.com/watch?v=83xBPCw5hh4",
       "singer": "dababy",
       "title": "Rockstar"
     },
@@ -781,42 +781,42 @@
       "title": "yummy"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=fwK7ggA3-bU",
+      "url": "https://www.youtube.com/watch?v=fwK7ggA3-bU",
       "singer": "maroon 5",
       "title": "one more night"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=pPw_izFr5PA",
+      "url": "https://www.youtube.com/watch?v=pPw_izFr5PA",
       "singer": "6ix9ine",
       "title": "GOOBA"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=UYwF-jdcVjY",
+      "url": "https://www.youtube.com/watch?v=UYwF-jdcVjY",
       "singer": "post malone",
       "title": "better now"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=fEUS_NP5Qzo",
+      "url": "https://www.youtube.com/watch?v=fEUS_NP5Qzo",
       "singer": "blackbear",
       "title": "chateau"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=WagT4pdaPG8",
+      "url": "https://www.youtube.com/watch?v=WagT4pdaPG8",
       "singer": "CMG",
       "title": "stonner"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=CxnaPa8ohmM",
+      "url": "https://www.youtube.com/watch?v=CxnaPa8ohmM",
       "singer": "g-eazy",
       "title": "i mean it"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=cwQgjq0mCdE",
+      "url": "https://www.youtube.com/watch?v=cwQgjq0mCdE",
       "singer": "kanye west",
       "title": "i love it"
     },
     {
-      "url": "https://www.youtube.com\/watch?v=QYh6mYIJG2Y",
+      "url": "https://www.youtube.com/watch?v=QYh6mYIJG2Y",
       "singer": "ariana grande",
       "title": "7 rings"
     }


### PR DESCRIPTION
possible fix for #217  hang up
after testing found that links like
`      "url": "https://www.youtube.com\/watch?v=CxnaPa8ohmM",
` will cause the trivia command to try `https://www.youtube.com//watch?v=CxnaPa8ohmM` and gets a bad result where the bot will sometimes think its not a direct link

can also sometimes trigger a Search result instead of just playing the music when i ran links like  `"https://www.youtube.com\/watch?v=CxnaPa8ohmM"
` through the `!play` command
 
wasn't able to finish 15 round games, I got to 10 (furthest I've ever gotten to consistently) before I ran out of time for the day.

Much Love
-Bacon