### PR TITLE
Bug fix for #272 replace all the HTML special characters to proper special characters

### DIFF
--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -182,7 +182,7 @@ module.exports = class PlayCommand extends Command {
     }
     const vidNameArr = [];
     for (let i = 0; i < videos.length; i++) {
-      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&#39;/g, "'").replace(/quot;/g, `"`).replace(/&amp;/g, "&")}](${videos[i].shortURL})`);
+      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&#39;/g, "'").replace(/quot;/g, `"`).replace(/&amp;/g, " & ")}](${videos[i].shortURL})`);
     }
     vidNameArr.push('cancel');
     const embed = new MessageEmbed()

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -182,7 +182,11 @@ module.exports = class PlayCommand extends Command {
     }
     const vidNameArr = [];
     for (let i = 0; i < videos.length; i++) {
-      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&#39;/g, "'").replace(/quot;/g, `"`).replace(/&amp;/g, " & ")}](${videos[i].shortURL})`);
+      vidNameArr.push(`${i + 1}: [${videos[i].title.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&apos;", "'")
+        .replace(/&quot;/g, '"')
+        .replace("&amp;", "&")}](${videos[i].shortURL})`);
     }
     vidNameArr.push('cancel');
     const embed = new MessageEmbed()

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -182,7 +182,7 @@ module.exports = class PlayCommand extends Command {
     }
     const vidNameArr = [];
     for (let i = 0; i < videos.length; i++) {
-      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&#39;/g, "'").replace(/quot;/g, `"`)}](${videos[i].shortURL})`);
+      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&#39;/g, "'").replace(/quot;/g, `"`).replace(/&amp;/g, "&")}](${videos[i].shortURL})`);
     }
     vidNameArr.push('cancel');
     const embed = new MessageEmbed()

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -182,11 +182,11 @@ module.exports = class PlayCommand extends Command {
     }
     const vidNameArr = [];
     for (let i = 0; i < videos.length; i++) {
-      vidNameArr.push(`${i + 1}: [${videos[i].title.replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&apos;", "'")
+      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&apos;/g, "'")
         .replace(/&quot;/g, '"')
-        .replace("&amp;", "&")}](${videos[i].shortURL})`);
+        .replace(/&amp;/g, "&")}](${videos[i].shortURL})`);
     }
     vidNameArr.push('cancel');
     const embed = new MessageEmbed()

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -182,11 +182,13 @@ module.exports = class PlayCommand extends Command {
     }
     const vidNameArr = [];
     for (let i = 0; i < videos.length; i++) {
-      vidNameArr.push(`${i + 1}: [${videos[i].title.replace(/&lt;/g, "<")
+      vidNameArr.push(`${i + 1}: [${videos[i].title
+        .replace(/&lt;/g, "<")
         .replace(/&gt;/g, ">")
         .replace(/&apos;/g, "'")
         .replace(/&quot;/g, '"')
-        .replace(/&amp;/g, "&")}](${videos[i].shortURL})`);
+        .replace(/&amp;/g, "&")
+        .replace(/&#39;/g, "'")}](${videos[i].shortURL})`);
     }
     vidNameArr.push('cancel');
     const embed = new MessageEmbed()


### PR DESCRIPTION
Fix for #272
Replaces all the `&#39;,&lt;,&gt;,&apos;,&quot;,&amp;` to `<>'"&` in the `!play` commands search results.
 - **Before**
![search weirdness](https://user-images.githubusercontent.com/12632936/98152369-3ac7ce00-1e97-11eb-9795-a1b9889756ef.PNG)
- **After**
![search fix](https://user-images.githubusercontent.com/12632936/98152439-592dc980-1e97-11eb-95e2-96571881f8f8.PNG)

If there is any more of these special characters that are not showing up just let us know, and we can sort you out.

Much Love
-Bacon