### PR TITLE
Update play.js Fix for Video Stream Error and Speed up for Pi in between songs

### DIFF
--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -261,6 +261,7 @@ module.exports = class PlayCommand extends Command {
         const dispatcher = connection
           .play(
             ytdl(queue[0].url, {
+              filter: 'audio',
               quality: 'highestaudio',
               highWaterMark: 1 << 25
             })


### PR DESCRIPTION
Fix the Video stream error and to help with response time in between songs and starting a song 

added `filter: 'audio'`

this lowered my delay between songs and helped with errors with some songs not playing
Raspberry Pi had the most noticeable decrease in delay between songs in queue and stopped the `Video stream Error` i was getting during a torture test of 200 songs

- The Enemy
![image](https://user-images.githubusercontent.com/12632936/99476401-1c8db380-2916-11eb-9d52-9e794d5b475f.png)



mission was to have the song requested and heard from [Tron Legacy OST Album playlist](https://www.youtube.com/watch?v=b8OELzmpgZo&list=PLA0297420F2C5554C) 20 songs without a failure 10 times (removed 2 cuz i like the number 20) 
 
Torture Test 200 song queues Skipping 20sec after the song plays (to catch the `Video stream error` if it occurred)
OP Workstation Windows 10, Ubuntu  - no difference in time but no `Video stream errors`
Pi 3b+ Raspberry OS 10 - 1.9 seconds to ~ 0.5 seconds and no `Video stream errors `
*times are an average and  were measured from the point of `!skip` to the embed popup and
 
and yes I did run 800 songs eh about 6 hours of testing(the best part in my opinion)

Lol I apologize for not providing a screenshot of after the addition but I feel an 800 song picture would implode space and time

Much Love
-Bacon