### PR TITLE
Welcome message toggle 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 | !ban                  | Bans a tagged member            | !ban @johndoe                         |
 | !kick                 | Kicks a tagged member           | !kick @johndoe                        |
 | !prune                | Delete up to 99 recent messages | !prune 50                             |
+| !welcome-message      | Allows you to toggle the welcome message for new members that join the server.| !welcome-message enable |
 
 ### Resources
 

--- a/commands/guild/welcome.js
+++ b/commands/guild/welcome.js
@@ -9,7 +9,7 @@ module.exports = class WecomeMessageCommand extends Command {
             group: "guild",
             guildOnly: true,
             clientPermissions: ['ADMINISTRATOR'],
-            description: "Askes if you want your server to have Welcome messages.",
+            description: "Asks if you want your server to have Welcome messages.",
             args: [
                 {
                     key: "choice",
@@ -25,10 +25,10 @@ module.exports = class WecomeMessageCommand extends Command {
     run(message, { choice }) {
         db.set(message.member.guild.id, { welcomeMsgStatus: choice.toLowerCase() });
         
-        if (choice == 'yes')
+        if (choice.toLowerCase() == 'yes')
             message.say(`Welcome Message Enabled on ${message.member.guild.name}`)
          
-        if (choice == 'no')
+        if (choice.toLowerCase() == 'no')
             message.say(`Welcome Message Disabled on ${message.member.guild.name}`)
     }
 }

--- a/commands/guild/welcome.js
+++ b/commands/guild/welcome.js
@@ -1,0 +1,34 @@
+const { Command } = require("discord.js-commando");
+const db = require('quick.db');
+
+module.exports = class WecomeMessageCommand extends Command {
+    constructor(client) {
+        super(client, {
+            name: "welcome",
+            memberName: "welcome",
+            group: "guild",
+            guildOnly: true,
+            clientPermissions: ['ADMINISTRATOR'],
+            description: "Askes if you want your server to have Welcome messages.",
+            args: [
+                {
+                    key: "choice",
+                    prompt: "Do you want welcome new users with a custom messages? Type: Yes or No",
+                    type: "string",
+                    oneOf: ['yes', 'no' ]                                   
+                }
+            ]
+        });
+    }
+
+ 
+    run(message, { choice }) {
+        db.set(message.member.guild.id, { welcomeMsgStatus: choice.toLowerCase() });
+        
+        if (choice == 'yes')
+            message.say(`Welcome Message Enabled on ${message.member.guild.name}`)
+         
+        if (choice == 'no')
+            message.say(`Welcome Message Disabled on ${message.member.guild.name}`)
+    }
+}

--- a/commands/guild/welcome.js
+++ b/commands/guild/welcome.js
@@ -10,12 +10,12 @@ module.exports = class WecomeMessageCommand extends Command {
       group: 'guild',
       guildOnly: true,
       clientPermissions: ['ADMINISTRATOR'],
-      description: 'Allows you to toggle the welcome message for new members that join the server',
+      description: 'Allows you to toggle the welcome message for new members that join the server.',
       args: [
         {
           key: 'choice',
           prompt:
-            'Do you want welcome new users with a custom messages? Type: Yes or No',
+            'Do you want me to welcome new members? Type Yes or No',
           type: 'string',
           oneOf: ['yes', 'no', 'enable', 'disable']
         }

--- a/commands/guild/welcome.js
+++ b/commands/guild/welcome.js
@@ -1,34 +1,39 @@
-const { Command } = require("discord.js-commando");
+const { Command } = require('discord.js-commando');
 const db = require('quick.db');
 
 module.exports = class WecomeMessageCommand extends Command {
-    constructor(client) {
-        super(client, {
-            name: "welcome",
-            memberName: "welcome",
-            group: "guild",
-            guildOnly: true,
-            clientPermissions: ['ADMINISTRATOR'],
-            description: "Asks if you want your server to have Welcome messages.",
-            args: [
-                {
-                    key: "choice",
-                    prompt: "Do you want welcome new users with a custom messages? Type: Yes or No",
-                    type: "string",
-                    oneOf: ['yes', 'no' ]                                   
-                }
-            ]
-        });
-    }
+  constructor(client) {
+    super(client, {
+      name: 'welcome-message',
+      memberName: 'welcome-message',
+      aliases: ['welcomemessage', 'welcome'],
+      group: 'guild',
+      guildOnly: true,
+      clientPermissions: ['ADMINISTRATOR'],
+      description: 'Allows you to toggle the welcome message for new members that join the server',
+      args: [
+        {
+          key: 'choice',
+          prompt:
+            'Do you want welcome new users with a custom messages? Type: Yes or No',
+          type: 'string',
+          oneOf: ['yes', 'no', 'enable', 'disable']
+        }
+      ]
+    });
+  }
 
- 
-    run(message, { choice }) {
-        db.set(message.member.guild.id, { welcomeMsgStatus: choice.toLowerCase() });
-        
-        if (choice.toLowerCase() == 'yes')
-            message.say(`Welcome Message Enabled on ${message.member.guild.name}`)
-         
-        if (choice.toLowerCase() == 'no')
-            message.say(`Welcome Message Disabled on ${message.member.guild.name}`)
-    }
-}
+  run(message, { choice }) {
+    if (choice.toLowerCase() == 'enable') var choice = 'yes';
+
+    if (choice.toLowerCase() == 'disable') var choice = 'no';
+
+    db.set(message.member.guild.id, { welcomeMsgStatus: choice.toLowerCase() });
+
+    if (choice.toLowerCase() == 'yes')
+      message.say(`Welcome Message Enabled on ${message.member.guild.name}`);
+
+    if (choice.toLowerCase() == 'no')
+      message.say(`Welcome Message Disabled on ${message.member.guild.name}`);
+  }
+};

--- a/commands/guild/welcome.js
+++ b/commands/guild/welcome.js
@@ -24,9 +24,9 @@ module.exports = class WecomeMessageCommand extends Command {
   }
 
   run(message, { choice }) {
-    if (choice.toLowerCase() == 'enable') var choice = 'yes';
+    if (choice.toLowerCase() == 'enable')  choice = 'yes';
 
-    if (choice.toLowerCase() == 'disable') var choice = 'no';
+    if (choice.toLowerCase() == 'disable')  choice = 'no';
 
     db.set(message.member.guild.id, { welcomeMsgStatus: choice.toLowerCase() });
 

--- a/index.js
+++ b/index.js
@@ -82,28 +82,25 @@ client.on('voiceStateUpdate', async (___, newState) => {
   }
 });
 
-
-// Custom Welcome Image for new members
 client.on('guildMemberAdd', async member => {
-  let welcomeGuildFetch = db.get(member.guild.id);
-   if (!welcomeGuildFetch) 
-      return;
-  
-  let welcomeMessageSetting = welcomeGuildFetch.welcomeMsgStatus;
-  if (welcomeMessageSetting == 'no') 
-    return;
-    
+  const welcomeGuildFetch = db.get(member.guild.id);
+  if (!welcomeGuildFetch) return;
+
+  const welcomeMessageSetting = welcomeGuildFetch.welcomeMsgStatus;
+  if (welcomeMessageSetting == 'no') return;
+
   if (welcomeMessageSetting == 'yes') {
     const applyText = (canvas, text) => {
       const ctx = canvas.getContext('2d');
       let fontSize = 70;
-    
+
       do {
         ctx.font = `${(fontSize -= 10)}px sans-serif`;
       } while (ctx.measureText(text).width > canvas.width - 300);
-    
+
       return ctx.font;
     };
+    // Custom Welcome Image for new members
     const canvas = Canvas.createCanvas(700, 250); // Set the dimensions (Width, Height)
     const ctx = canvas.getContext('2d');
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { CommandoClient } = require('discord.js-commando');
 const { Structures, MessageEmbed, MessageAttachment } = require('discord.js');
 const path = require('path');
 const { prefix, token, discord_owner_id } = require('./config.json');
+const db = require('quick.db');
 const Canvas = require('canvas');
 
 Structures.extend('Guild', function(Guild) {
@@ -81,86 +82,96 @@ client.on('voiceStateUpdate', async (___, newState) => {
   }
 });
 
+
 // Custom Welcome Image for new members
-const applyText = (canvas, text) => {
-  const ctx = canvas.getContext('2d');
-  let fontSize = 70;
-
-  do {
-    ctx.font = `${(fontSize -= 10)}px sans-serif`;
-  } while (ctx.measureText(text).width > canvas.width - 300);
-
-  return ctx.font;
-};
-
 client.on('guildMemberAdd', async member => {
-  const canvas = Canvas.createCanvas(700, 250); // Set the dimensions (Width, Height)
-  const ctx = canvas.getContext('2d');
+  let welcomeGuildFetch = db.get(member.guild.id);
+   if (!welcomeGuildFetch) 
+      return;
+  
+  let welcomeMessageSetting = welcomeGuildFetch.welcomeMsgStatus;
+  if (welcomeMessageSetting == 'no') 
+    return;
+    
+  if (welcomeMessageSetting == 'yes') {
+    const applyText = (canvas, text) => {
+      const ctx = canvas.getContext('2d');
+      let fontSize = 70;
+    
+      do {
+        ctx.font = `${(fontSize -= 10)}px sans-serif`;
+      } while (ctx.measureText(text).width > canvas.width - 300);
+    
+      return ctx.font;
+    };
+    const canvas = Canvas.createCanvas(700, 250); // Set the dimensions (Width, Height)
+    const ctx = canvas.getContext('2d');
 
-  const background = await Canvas.loadImage(
-    './resources/welcome/wallpaper.jpg' // can add what ever image you want for the Background just make sure that the filename matches
-  );
-  ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
+    const background = await Canvas.loadImage(
+      './resources/welcome/wallpaper.jpg' // can add what ever image you want for the Background just make sure that the filename matches
+    );
+    ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
 
-  ctx.strokeStyle = '#000000'; // the color of the trim on the outside of the welcome image
-  ctx.strokeRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = '#000000'; // the color of the trim on the outside of the welcome image
+    ctx.strokeRect(0, 0, canvas.width, canvas.height);
 
-  ctx.font = '26px sans-serif';
-  ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
-  ctx.fillText(
-    `Welcome to ${member.guild.name}`,
-    canvas.width / 2.5,
-    canvas.height / 3.5
-  );
-  ctx.strokeStyle = `#FFFFFF`; // Secondary Color of Text on the top of welcome for depth/shadow the stroke is under the main color
-  ctx.strokeText(
-    `Welcome to ${member.guild.name}`,
-    canvas.width / 2.5,
-    canvas.height / 3.5
-  );
+    ctx.font = '26px sans-serif';
+    ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
+    ctx.fillText(
+      `Welcome to ${member.guild.name}`,
+      canvas.width / 2.5,
+      canvas.height / 3.5
+    );
+    ctx.strokeStyle = `#FFFFFF`; // Secondary Color of Text on the top of welcome for depth/shadow the stroke is under the main color
+    ctx.strokeText(
+      `Welcome to ${member.guild.name}`,
+      canvas.width / 2.5,
+      canvas.height / 3.5
+    );
 
-  ctx.font = applyText(canvas, `${member.displayName}!`);
-  ctx.fillStyle = '#FFFFFF'; // Main Color for the members name for the welcome image
-  ctx.fillText(
-    `${member.displayName}!`,
-    canvas.width / 2.5,
-    canvas.height / 1.8
-  );
-  ctx.strokeStyle = `#FF0000`; // Secondary Color for the member name to add depth/shadow to the text
-  ctx.strokeText(
-    `${member.displayName}!`,
-    canvas.width / 2.5,
-    canvas.height / 1.8
-  );
+    ctx.font = applyText(canvas, `${member.displayName}!`);
+    ctx.fillStyle = '#FFFFFF'; // Main Color for the members name for the welcome image
+    ctx.fillText(
+      `${member.displayName}!`,
+      canvas.width / 2.5,
+      canvas.height / 1.8
+    );
+    ctx.strokeStyle = `#FF0000`; // Secondary Color for the member name to add depth/shadow to the text
+    ctx.strokeText(
+      `${member.displayName}!`,
+      canvas.width / 2.5,
+      canvas.height / 1.8
+    );
 
-  ctx.beginPath();
-  ctx.arc(125, 125, 100, 0, Math.PI * 2, true);
-  ctx.closePath();
-  ctx.clip();
+    ctx.beginPath();
+    ctx.arc(125, 125, 100, 0, Math.PI * 2, true);
+    ctx.closePath();
+    ctx.clip();
 
-  const avatar = await Canvas.loadImage(
-    member.user.displayAvatarURL({ format: 'jpg' })
-  );
-  ctx.drawImage(avatar, 25, 25, 200, 200);
+    const avatar = await Canvas.loadImage(
+      member.user.displayAvatarURL({ format: 'jpg' })
+    );
+    ctx.drawImage(avatar, 25, 25, 200, 200);
 
-  const attachment = new MessageAttachment(
-    canvas.toBuffer(),
-    'welcome-image.png'
-  );
+    const attachment = new MessageAttachment(
+      canvas.toBuffer(),
+      'welcome-image.png'
+    );
 
-  var embed = new MessageEmbed()
-    .setTitle(
-      `:speech_balloon: Hey ${member.displayName}, You look new to ${member.guild.name}!`
-    )
-    .setColor(`RANDOM`)
-    .attachFiles(attachment)
-    .setImage('attachment://welcome-image.png')
-    .setFooter(`Type help for a feature list!`)
-    .setTimestamp();
-  try {
-    await member.user.send(embed);
-  } catch {
-    console.log(`${member.user.username}'s dms are private`);
+    var embed = new MessageEmbed()
+      .setTitle(
+        `:speech_balloon: Hey ${member.displayName}, You look new to ${member.guild.name}!`
+      )
+      .setColor(`RANDOM`)
+      .attachFiles(attachment)
+      .setImage('attachment://welcome-image.png')
+      .setFooter(`Type help for a feature list!`)
+      .setTimestamp();
+    try {
+      await member.user.send(embed);
+    } catch {
+      console.log(`${member.user.username}'s dms are private`);
+    }
   }
 });
 


### PR DESCRIPTION
Requested by #301

Welcome message comes disabled by default and can be toggled on by a Guild Admin with a `!welcome-message enable` command. Choice is saved to `json.sqlite` file

Adds `!welcome yes` , `!welcome no`, `!welcome enable`, `!welcome-message disable` only if the user is admin

![image](https://user-images.githubusercontent.com/12632936/99608483-9768d400-29d3-11eb-812a-ca26a2215bfe.png)
