### PR TITLE
icon change for `Help` Guild Related Commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ client.registry
     ['music', ':notes: Music Command Group:'],
     ['gifs', ':film_frames: Gif Command Group:'],
     ['other', ':loud_sound: Other Command Group:'],
-    ['guild', ':speaker: Guild Related Commands:']
+    ['guild', ':gear: Guild Related Commands:']
   ])
   .registerDefaultGroups()
   .registerDefaultCommands({


### PR DESCRIPTION
Now that there is more than just Ban, Kick, and Prune  it made more sense to have a 'Settings' icon rather than a speaker 
![image](https://user-images.githubusercontent.com/12632936/99840613-7e2a6980-2b32-11eb-9888-616dad1a9874.png)

Much Love
-Bacon
