### PR TITLE
Update Pi_Instructions.md

### DIFF
--- a/Pi_Instructions.md
+++ b/Pi_Instructions.md
@@ -9,7 +9,7 @@ sudo apt-get updgrade
 ### Checking and Installing needed Dependencies 
 
 ### Complier
-Quick.db and Cavvas both need a Compiler in order to install on a PI
+Quick.db and Canvas both need a Compiler in order to install on a PI
 ```
 sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`
 ```

--- a/Pi_Instructions.md
+++ b/Pi_Instructions.md
@@ -8,6 +8,13 @@ sudo apt-get updgrade
 
 ### Checking and Installing needed Dependencies 
 
+### Complier
+Quick.db and Cavvas both need a Compiler in order to install on a PI
+```
+sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`
+```
+to install a compliler and the image support for Canvas
+
 ### Python
 ```
 cd ~

--- a/Pi_Instructions.md
+++ b/Pi_Instructions.md
@@ -8,7 +8,7 @@ sudo apt-get updgrade
 
 ### Checking and Installing needed Dependencies 
 
-### Complier
+### Compiler
 Quick.db and Canvas both need a Compiler in order to install on a PI
 ```
 sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`


### PR DESCRIPTION
Addressing #324 


Added instruction to install a compiler for quick.db and Canvas install issue when no compiler is present

Noticed on during issue testing
CLI install (no ffmpeg, jpeg support, python, and no native compiler) for dependencies that required to be built on the Arm6 and Arm7

Recommended install (just needs the compiler for quick.db and canvas Plus Lib support) to be built
 
Much Love
-Bacon
