### PR TITLE
Update Pi_Instructions.md

### DIFF
--- a/Pi_Instructions.md
+++ b/Pi_Instructions.md
@@ -11,7 +11,7 @@ sudo apt-get updgrade
 ### Compiler
 Quick.db and Canvas both need a Compiler in order to install on a PI
 ```
-sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`
+sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 ```
 to install a compliler and the image support for Canvas
 

--- a/Pi_Instructions.md
+++ b/Pi_Instructions.md
@@ -79,7 +79,7 @@ I use 14.10.0 because of a bug in the latest v14.15.0 build
 
 ```
 cd ~
-wget https://unofficial-builds.nodejs.org/download/release/v14.10.0/node-v14.15.0-linux-armv6l.tar.gz
+wget https://unofficial-builds.nodejs.org/download/release/v14.10.0/node-v14.10.0-linux-armv6l.tar.gz
 tar -xzf node-v14.10.0-linux-armv6l.tar.gz
 node-v14.10.0-linux-armv6l/bin/node -v
 ```
@@ -88,7 +88,7 @@ The last command should print v14.10.0.
 Now you can copy it to `/usr/local`
 
 ```
-cd node-v14.12.0-linux-armv6l/
+cd node-v14.10.0-linux-armv6l/
 sudo cp -R * /usr/local/
 ```
 Now let's check if it was successful


### PR DESCRIPTION
A friend of mine just recently set up a Pi 2 and noticed a mistake, I messed up the URLs/Path on Arm 6 Node instructions

probably when I ran into a Build issue on Arm 6 with Node V14.15.0 and forgot to change it 

- Arm 6 Notes
Currently, only works with Node 12.x to 14.10.0 (to run Master-Bot)(14.10.0 is the Quickest version on an Arm6 that I found during compatibility testing)
Node 14.11.0 to 14.15.1 won't build Canvas or quick.db on the Arm 6 during the `npm i`
4 fresh installations using only instructions on a Pi Zero (so I don't make the same mistake) 
previous test only checked if it could work on arm6 and 7 (I apologize for the improper testing method. I didn't check if the commands were correct, I entered the commands manually)

Much Love
-Bacon