### PR TITLE
Create nickname.js

### DIFF
--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -1,0 +1,75 @@
+const { Command } = require('discord.js-commando');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class NicknameCommand extends Command {
+  constructor (client) {
+    super(client, {
+      name: 'nickname',
+      aliases: ['set-nick', 'set-nickname'],
+      group: 'guild',
+      memberName: 'nickname',
+      description: 'Sets the selected member\'s nickname with the provided nickname',
+      clientPermissions: ['MANAGE_NICKNAMES'],
+      userPermissions: ['MANAGE_NICKNAMES'],
+      guildOnly: true,
+      args: [
+        {
+            key: 'member',
+            prompt: 'Which member do you want to change the nickname of?',
+            type: 'member'
+        },
+        {
+            key: 'nickname',
+            prompt: 'What name do you want to change their nickname to?',
+            type: 'string'
+        }
+    ]
+    });
+  }
+
+  async run (message, { member, nickname }) {
+  	
+  	if(nickname === 'remove') {
+  		await member.setNickname('');
+  		
+  		const nickRemoved = new MessageEmbed()
+  		   .setColor('RANDOM')
+  		   .setTitle('Nickname Cleared!')
+  		   .addField('Member', `<@${member.id}>`)
+  		   .addField('Moderator', `${message.author}`);
+  		   
+  		  //deletes message from author
+  		  /* 
+  		   if(message.deletable) {
+  		   	  message.delete();
+  		   }
+  		  */
+  		   
+  		message.channel.send(nickRemoved);
+  		
+  	} else {
+  		
+    const oldName = member.displayName;
+    const nicknameEmbed = new MessageEmbed();
+
+    member.setNickname(nickname);
+
+    nicknameEmbed
+      .setColor('RANDOM')
+      .setTitle('Nickname Changed!')
+      .addField('Member', `<@${member.id}>`)
+      .addField('Old Name',`• ${oldName}`)
+      .addField('New Name',`• ${nickname}`)
+      .addField('Moderator', `${message.author}`);
+
+    //deletes message from author
+    /*
+    if (message.deletable) {
+        message.delete();
+    }
+    */
+
+    message.say(nicknameEmbed);
+    }
+  }
+};

--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -5,8 +5,8 @@ module.exports = class NicknameCommand extends Command {
   constructor (client) {
     super(client, {
       name: 'nickname',
-      aliases: ['set-nick', 'set-nickname'],
-      group: 'guild',
+      aliases: ['nick'],
+      group: 'moderation',
       memberName: 'nickname',
       description: 'Sets the selected member\'s nickname with the provided nickname',
       clientPermissions: ['MANAGE_NICKNAMES'],
@@ -28,21 +28,23 @@ module.exports = class NicknameCommand extends Command {
   }
 
 async run (message, { member, nickname }) {
-if(nickname === 'remove') {
-  await member.setNickname('');
+     if(nickname === 'remove') {
+        const nickRemoved = new MessageEmbed();
+		
+  	await member.setNickname('');
   		
-  const nickRemoved = new MessageEmbed()
-      .setColor('RANDOM')
-      .setTitle('Nickname Cleared!')
-      .addField('Member', `<@${member.id}>`)
-      .addField('Moderator', `${message.author}`);
+  	nickRemoved	
+  	  .setColor('RANDOM')
+  	  .setTitle('Nickname Cleared!')
+  	  .addField('Member', `<@${member.id}>`)
+  	  .addField('Moderator', `${message.author}`);
   		   
-     //deletes message from author
-     /* 
-     if(message.deletable) {
+        //deletes message from author
+  	/* 
+  	if(message.deletable) {
   	message.delete();
-     }
-     */
+        }
+        */ 
   		   
   return message.channel.send(nickRemoved);
   		
@@ -51,14 +53,14 @@ if(nickname === 'remove') {
     const oldName = member.displayName;
     const nicknameEmbed = new MessageEmbed();
 
-    member.setNickname(nickname);
+    await member.setNickname(nickname);
 
     nicknameEmbed
       .setColor('RANDOM')
       .setTitle('Nickname Changed!')
       .addField('Member', `<@${member.id}>`)
-      .addField('Old Name',`• ${oldName}`)
-      .addField('New Name',`• ${nickname}`)
+      .addField('Old Name', `${oldName}`)
+      .addField('New Name', `${nickname}`)
       .addField('Moderator', `${message.author}`);
 
     //deletes message from author
@@ -68,7 +70,7 @@ if(nickname === 'remove') {
     }
     */
 
-    message.say(nicknameEmbed);
+    return message.channel.send(nicknameEmbed);
     }
   }
 };

--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -27,25 +27,24 @@ module.exports = class NicknameCommand extends Command {
     });
   }
 
-  async run (message, { member, nickname }) {
-  	
-  	if(nickname === 'remove') {
-  		await member.setNickname('');
+async run (message, { member, nickname }) {
+	if(nickname === 'remove') {
+  	await member.setNickname('');
   		
-  		const nickRemoved = new MessageEmbed()
-  		   .setColor('RANDOM')
-  		   .setTitle('Nickname Cleared!')
-  		   .addField('Member', `<@${member.id}>`)
-  		   .addField('Moderator', `${message.author}`);
+  	const nickRemoved = new MessageEmbed()
+  		  .setColor('RANDOM')
+  		  .setTitle('Nickname Cleared!')
+  		  .addField('Member', `<@${member.id}>`)
+  		  .addField('Moderator', `${message.author}`);
   		   
   		  //deletes message from author
   		  /* 
-  		   if(message.deletable) {
-  		   	  message.delete();
-  		   }
+  		  if(message.deletable) {
+  		     message.delete();
+  		  }
   		  */
   		   
-  		message.channel.send(nickRemoved);
+   message.channel.send(nickRemoved);
   		
   	} else {
   		

--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -5,8 +5,8 @@ module.exports = class NicknameCommand extends Command {
   constructor (client) {
     super(client, {
       name: 'nickname',
-      aliases: ['nick'],
-      group: 'moderation',
+      aliases: ['set-nick', 'set-nickname'],
+      group: 'guild',
       memberName: 'nickname',
       description: 'Sets the selected member\'s nickname with the provided nickname',
       clientPermissions: ['MANAGE_NICKNAMES'],

--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -44,7 +44,7 @@ if(nickname === 'remove') {
      }
      */
   		   
-  message.channel.send(nickRemoved);
+  return message.channel.send(nickRemoved);
   		
   	} else {
   		

--- a/commands/guild/nickname.js
+++ b/commands/guild/nickname.js
@@ -28,23 +28,23 @@ module.exports = class NicknameCommand extends Command {
   }
 
 async run (message, { member, nickname }) {
-	if(nickname === 'remove') {
-  	await member.setNickname('');
+if(nickname === 'remove') {
+  await member.setNickname('');
   		
-  	const nickRemoved = new MessageEmbed()
-  		  .setColor('RANDOM')
-  		  .setTitle('Nickname Cleared!')
-  		  .addField('Member', `<@${member.id}>`)
-  		  .addField('Moderator', `${message.author}`);
+  const nickRemoved = new MessageEmbed()
+      .setColor('RANDOM')
+      .setTitle('Nickname Cleared!')
+      .addField('Member', `<@${member.id}>`)
+      .addField('Moderator', `${message.author}`);
   		   
-  		  //deletes message from author
-  		  /* 
-  		  if(message.deletable) {
-  		     message.delete();
-  		  }
-  		  */
+     //deletes message from author
+     /* 
+     if(message.deletable) {
+  	message.delete();
+     }
+     */
   		   
-   message.channel.send(nickRemoved);
+  message.channel.send(nickRemoved);
   		
   	} else {
   		


### PR DESCRIPTION
Set nickname command where a guild member can set other guild member's nickname.

Permission needed:
- `MANAGE_NICKNAMES` 
     - *(both client and user)*

Usage:
- To set someone's nickname on the server.
     - `${prefix} nickname <guildMember> <newNickname>`
- To remove/clear someone's nickname on the server.
     - `${prefix} nickname <guildMember> remove`

Image Example:
![Setting, Removing Nickname](https://i.postimg.cc/9XnX0dGJ/Screenshot-2020-1130-205028.png)

- Feel free to edit it.