### PR TITLE
Twitch announcer .... patch

### DIFF
--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -128,6 +128,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
     Twitch_DB.set(`${message.guild.id}.twitchAnnouncer`, {
       botSay: sayMsg,
       name: user.data[0].display_name,
+      channelID: announcedChannel.id,
       channel: announcedChannel.name,
       timer: timer,
       savedName: message.member.displayName,

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -58,7 +58,6 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           `${prefix}twitch-announcer-settings` +
           '` first'
       );
-    message.delete();
 
     //Get Twitch Ready for Response Embeds
     const scope = 'user:read:email';
@@ -171,7 +170,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         }
 
         let announcedChannel = message.guild.channels.cache.find(
-          channel => channel.name == DBInfo.channel
+          channel => channel.id == DBInfo.channelID
         );
         try {
           access_token = await TwitchStatusCommand.getToken(
@@ -307,6 +306,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
 
         //Offline Trigger
         if (currentMsgStatus == 'offline') {
+          currentMsgStatus = 'end';
           const offlineEmbed = new MessageEmbed()
             .setAuthor(
               `Twitch Announcement: ${user.data[0].display_name} Offline`,
@@ -348,7 +348,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
               fetchedMsg.edit(offlineEmbed);
             });
         }
-      }, DBInfo.timer * 60000);
+      }, DBInfo.timer * 10000);
     }
   }
 };

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -348,7 +348,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
               fetchedMsg.edit(offlineEmbed);
             });
         }
-      }, DBInfo.timer * 10000);
+      }, DBInfo.timer * 60000);
     }
   }
 };


### PR DESCRIPTION
@galnir I apologize had a chance to test A ton of situations and found a few things

1. the `message.delete` was removed in twitch-announcer.js (could cause a deletion of an unintended message)
2. Fixed my goof with `messageFetch()` the Var was referenced to channel.name and not ID (would give a console error when streamer went offline)
3. added the `ChannelID` to the DB to Edit only the Online Embed when a Streamer goes offline

Much Love
-Bacon