### PR TITLE
Update musictrivia.json

### DIFF
--- a/resources/music/musictrivia.json
+++ b/resources/music/musictrivia.json
@@ -786,11 +786,6 @@
       "title": "one more night"
     },
     {
-      "url": "https://www.youtube.com/watch?v=pPw_izFr5PA",
-      "singer": "6ix9ine",
-      "title": "GOOBA"
-    },
-    {
       "url": "https://www.youtube.com/watch?v=UYwF-jdcVjY",
       "singer": "post malone",
       "title": "better now"


### PR DESCRIPTION
Addressing #380 

```
     {
       "url": "https://www.youtube.com/watch?v=pPw_izFr5PA",
       "singer": "6ix9ine",
       "title": "GOOBA"
     },
```
I think Singer "6ix9ine" can't be capitalized by line 255 of musictrivia.js as per the Original Issue
when I use `console.log(queue[0].singer)` with this as the only song, log showed `undefined`(like singer was gone) 

and a console error `TypeError: Cannot read property 'singer' of undefined` occurred and discord only displayed scoreboard(i only called 1 round) bonus all the rest of the music commands worked fine after the error


Added note
```
      "url": "https://www.youtube.com/watch?v=QYh6mYIJG2Y",
      "singer": "ariana grande",
      "title": "7 rings"
```
Not sure if Titles like "7 rings" would cause a similar issue with the capitalization where the First character is a Number
I didn't get an error with 7 rings running the same test setup

Edit: i think its the space in '7 rings' that lets it work
i thought i was messing something up(or just going crazy) but yeah "6ix9ine" will show nothing but "6 ix9ine" will work(but it's not his name though)

Much Love
-Bacon