### PR TITLE
Twitch Api function separation from twitchstatus.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 
 - Guild
 
-| Command          | Description                                                                    | Usage                   |
-| ---------------- | ------------------------------------------------------------------------------ | ----------------------- |
-| !ban             | Bans a tagged member                                                           | !ban @johndoe           |
-| !kick            | Kicks a tagged member                                                          | !kick @johndoe          |
-| !prune           | Delete up to 99 recent messages                                                | !prune 50               |
-| !welcome-message | Allows you to toggle the welcome message for new members that join the server. | !welcome-message enable |
+| Command                    | Description                                                                    | Usage                                |
+| -------------------------- | ------------------------------------------------------------------------------ | ------------------------------------ |
+| !ban                       | Bans a tagged member                                                           | !ban @johndoe                        |
+| !kick                      | Kicks a tagged member                                                          | !kick @johndoe                       |
+| !prune                     | Delete up to 99 recent messages                                                | !prune 50                            |
+| !welcome-message           | Allows you to toggle the welcome message for new members that join the server. | !welcome-message enable              |
+| !twitch-announcer          | Allows you to Enable, Disable or Check the Twitch Announcer.                   | !ta enable                           |
+| !twitch-announcer-settings | Settings for the Twitch Announcer.                                             | !tasettings bacon-fixation general 1 |
 
 ### Resources
 
@@ -120,11 +122,13 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 
 [Get a Genius API key here](https://genius.com/api-clients/new)
 
+[How to get Twitch API](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
+
 [Installing node.js on debian](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-node-js-application-for-production-on-debian-9)
 
 [Installing node.js on Windows](https://treehouse.github.io/installation-guides/windows/node-windows.html)
 
-[Installing bot on a Raspberry Pi](https://github.com/galnir/Master-Bot/blob/master/Pi_Instructions.md)
+[Installing on a Raspberry Pi](https://github.com/galnir/Master-Bot/blob/master/Pi_Instructions.md)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 
 [Get a Genius API key here](https://genius.com/api-clients/new)
 
-[How to get Twitch API](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
+[How to get Twitch API Key](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
 
 [Installing node.js on debian](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-node-js-application-for-production-on-debian-9)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 
 [Get a Genius API key here](https://genius.com/api-clients/new)
 
-[How to get Twitch API Key](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
+[How to get a Twitch API Key](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
 
 [Installing node.js on debian](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-node-js-application-for-production-on-debian-9)
 

--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -37,10 +37,10 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
         '`' + `${prefix}tasettings bacon-fixation general 3` + '`',
         `(Optional Message)`,
         '`' +
-          `${prefix}tasettings bacon-fixation 2 "Check out my stream"` +
+          `${prefix}tasettings bacon-fixation general 2 "Check out my stream"` +
           '`',
         '(Optional No Message)',
-        '`' + `${prefix}tasettings bacon-fixation 2 none` + '`'
+        '`' + `${prefix}tasettings bacon-fixation <channel-name> 2 none` + '`'
       ],
       description: 'Settings for the Twitch Announcer.',
       args: [
@@ -78,7 +78,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
   }
 
   async run(message, { textRaw, streamChannel, timer, sayMsg }) {
-   //Tests if Bot has the ability to alter messages
+    //Tests if Bot has the ability to alter messages
     try {
       await message.delete();
     } catch {
@@ -87,12 +87,12 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
       );
       return;
     }
-    
+
     // Search by name
     let announcedChannel = message.guild.channels.cache.find(
       channel => channel.name == streamChannel
     );
-    
+
     // Search by id
     if (message.guild.channels.cache.get(streamChannel))
       announcedChannel = message.guild.channels.cache.get(streamChannel);
@@ -176,7 +176,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
         )
         .setTimestamp();
     }
-    
+
     //Send Reponse
     message.say(embed);
   }

--- a/commands/other/twitchstatus.js
+++ b/commands/other/twitchstatus.js
@@ -1,12 +1,13 @@
-const fetch = require('node-fetch');
 const { Command } = require('discord.js-commando');
+const TwitchAPI = require('../../resources/twitch/twitch-api.js');
+const { MessageEmbed, MessageAttachment } = require('discord.js');
 const { twitchClientID, twitchClientSecret } = require('../../config.json');
-const { MessageEmbed } = require('discord.js');
+const Canvas = require('canvas');
+const probe = require('probe-image-size');
 
-if (twitchClientID == null || twitchClientSecret == null)
-  return console.log(
-    'INFO: TwitchStatus command removed from the list. \nMake sure you have twitchClientID and twitchToken in your config.json to use TwitchStatus command!'
-  );
+// Skips loading if not found in config.json
+if (twitchClientID == null || twitchClientSecret == null) return;
+
 module.exports = class TwitchStatusCommand extends Command {
   constructor(client) {
     super(client, {
@@ -31,11 +32,14 @@ module.exports = class TwitchStatusCommand extends Command {
   }
 
   async run(message, { textRaw }) {
+    
+    // Twitch Section
     const scope = 'user:read:email';
     const textFiltered = textRaw.replace(/https\:\/\/twitch.tv\//g, '');
     let access_token;
+    
     try {
-      access_token = await TwitchStatusCommand.getToken(
+      access_token = await TwitchAPI.getToken(
         twitchClientID,
         twitchClientSecret,
         scope
@@ -46,7 +50,7 @@ module.exports = class TwitchStatusCommand extends Command {
     }
 
     try {
-      var user = await TwitchStatusCommand.getUserInfo(
+      var user = await TwitchAPI.getUserInfo(
         access_token,
         twitchClientID,
         textFiltered
@@ -57,8 +61,9 @@ module.exports = class TwitchStatusCommand extends Command {
     }
 
     const user_id = user.data[0].id;
+    
     try {
-      var streamInfo = await TwitchStatusCommand.getStream(
+      var streamInfo = await TwitchAPI.getStream(
         access_token,
         twitchClientID,
         user_id
@@ -68,6 +73,7 @@ module.exports = class TwitchStatusCommand extends Command {
       return;
     }
 
+    //Offline Trigger
     if (streamInfo.data[0] == null) {
       const offlineEmbed = new MessageEmbed()
         .setAuthor(
@@ -102,17 +108,33 @@ module.exports = class TwitchStatusCommand extends Command {
       message.say(offlineEmbed);
       return;
     }
+    
+    // Box Art Recreation
     try {
-      var gameInfo = await TwitchStatusCommand.getGames(
+      var gameInfo = await TwitchAPI.getGames(
         access_token,
         twitchClientID,
         streamInfo.data[0].game_id
       );
+      var result = await probe(
+        gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
+      );
+      var canvas = Canvas.createCanvas(result.width, result.height);
+      var ctx = canvas.getContext('2d');
+      // Since the image takes time to load, you should await it
+      var background = await Canvas.loadImage(
+        gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
+      );
+      // This uses the canvas dimensions to stretch the image onto the entire canvas
+      ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
+      // Use helpful Attachment class structure to process the file for you
+      var attachment = new MessageAttachment(canvas.toBuffer(), 'box_art.png');
     } catch (e) {
       message.say(e);
       return;
     }
 
+    // Online Embed
     const onlineEmbed = new MessageEmbed()
       .setAuthor(
         'Streamer Status Check',
@@ -134,13 +156,9 @@ module.exports = class TwitchStatusCommand extends Command {
           .replace(/{width}x{height}/g, '1280x720')
           .concat('?r=' + Math.floor(Math.random() * 10000 + 1))
       )
-      .setTimestamp(streamInfo.data[0].started_at);
-    if (gameInfo.data[0].box_art_url.search(/.jpg/g))
-      onlineEmbed.setThumbnail(user.data[0].profile_image_url);
-    else
-      onlineEmbed.setThumbnail(
-        gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
-      );
+      .setTimestamp(streamInfo.data[0].started_at)
+      .attachFiles(attachment)
+      .setThumbnail('attachment://box_art.png');
     if (user.data[0].broadcaster_type == '')
       onlineEmbed.addField('Rank:', 'BASE!', true);
     else {
@@ -152,112 +170,5 @@ module.exports = class TwitchStatusCommand extends Command {
     }
     message.say(onlineEmbed);
     return;
-  }
-  static getToken(twitchClientID, twitchClientSecret, scope) {
-    return new Promise(async function fetchToken(resolve, reject) {
-      try {
-        const response = await fetch(
-          `https://id.twitch.tv/oauth2/token?client_id=${twitchClientID}&client_secret=${twitchClientSecret}&grant_type=client_credentials&scope=${scope}`,
-          {
-            method: 'POST'
-          }
-        );
-        const json = await response.json();
-        if (json.status == 400) {
-          reject(
-            'Something went wrong when trying to fetch a twitch access token'
-          );
-        } else {
-          resolve(json.access_token);
-        }
-      } catch (e) {
-        console.error(e);
-        reject('There was a problem fetching a token from the Twitch API');
-      }
-    });
-  }
-  static getUserInfo(token, client_id, username) {
-    return new Promise(async function fetchUserInfo(resolve, reject) {
-      try {
-        const response = await fetch(
-          `https://api.twitch.tv/helix/users?login=${username}`,
-          {
-            method: 'GET',
-            headers: {
-              'client-id': `${client_id}`,
-              Authorization: `Bearer ${token}`
-            }
-          }
-        );
-        const json = await response.json();
-        if (json.status == `400`) {
-          reject(`:x: ${username} was Invaild, Please try again.`);
-          return;
-        }
-
-        if (json.status == `429`) {
-          reject(`:x: Rate Limit exceeded. Please try again in a few minutes.`);
-          return;
-        }
-
-        if (json.status == `503`) {
-          reject(
-            `:x: Twitch service's are currently unavailable. Please try again later.`
-          );
-          return;
-        }
-
-        if (json.data[0] == null) {
-          reject(`:x: Streamer ${username} was not found, Please try again.`);
-          return;
-        }
-        resolve(json);
-      } catch (e) {
-        console.error(e);
-        reject('There was a problem fetching user info from the Twitch API');
-      }
-    });
-  }
-  static getStream(token, client_id, userID) {
-    return new Promise(async function fetchStream(resolve, reject) {
-      try {
-        const response = await fetch(
-          `https://api.twitch.tv/helix/streams?user_id=${userID}`,
-          {
-            method: 'GET',
-            headers: {
-              'client-id': `${client_id}`,
-              Authorization: `Bearer ${token}`
-            }
-          }
-        );
-        const json = await response.json();
-        resolve(json);
-      } catch (e) {
-        console.error(e);
-        reject('There was a problem fetching stream info from the Twitch API');
-      }
-    });
-  }
-  static getGames(token, client_id, game_id) {
-    return new Promise(async function fetchGames(resolve, reject) {
-      try {
-        const response = await fetch(
-          `https://api.twitch.tv/helix/games?id=${game_id}`,
-          {
-            method: 'GET',
-            headers: {
-              'client-id': `${client_id}`,
-              Authorization: `Bearer ${token}`
-            }
-          }
-        );
-        const json = await response.json();
-        resolve(json);
-      } catch (e) {
-        console.error(e);
-        reject('There was a problem fetching stream info from the Twitch API');
-      }
-    });
   }
 };

--- a/resources/twitch/twitch-api.js
+++ b/resources/twitch/twitch-api.js
@@ -1,0 +1,126 @@
+const fetch = require('node-fetch');
+const { twitchClientID, twitchClientSecret } = require('../../config.json');
+
+// Skips loading if not found in config.json
+if (twitchClientID == null || twitchClientSecret == null)
+  return console.log(
+    'INFO: Twitch Features were removed from the list. \nMake sure you have "twitchClientID" and "twitchClientSecret" in your config.json to use Twitch Features '
+  );
+
+module.exports = class TwitchAPI {
+  
+  //Access Token is valid for 24 Hours
+  static getToken(twitchClientID, twitchClientSecret, scope) {
+    return new Promise(async function fetchToken(resolve, reject) {
+      try {
+        const response = await fetch(
+          `https://id.twitch.tv/oauth2/token?client_id=${twitchClientID}&client_secret=${twitchClientSecret}&grant_type=client_credentials&scope=${scope}`,
+          {
+            method: 'POST'
+          }
+        );
+        const json = await response.json();
+        if (json.status == 400) {
+          reject(
+            'Something went wrong when trying to fetch a twitch access token'
+          );
+        } else {
+          resolve(json.access_token);
+        }
+      } catch (e) {
+        console.error(e);
+        reject('There was a problem fetching a token from the Twitch API');
+      }
+    });
+  }
+
+  //userInfo.data[0]
+  static getUserInfo(token, client_id, username) {
+    return new Promise(async function fetchUserInfo(resolve, reject) {
+      try {
+        const response = await fetch(
+          `https://api.twitch.tv/helix/users?login=${username}`,
+          {
+            method: 'GET',
+            headers: {
+              'client-id': `${client_id}`,
+              Authorization: `Bearer ${token}`
+            }
+          }
+        );
+        const json = await response.json();
+        if (json.status == `400`) {
+          reject(`:x: ${username} was Invaild, Please try again.`);
+          return;
+        }
+
+        if (json.status == `429`) {
+          reject(`:x: Rate Limit exceeded. Please try again in a few minutes.`);
+          return;
+        }
+
+        if (json.status == `503`) {
+          reject(
+            `:x: Twitch service's are currently unavailable. Please try again later.`
+          );
+          return;
+        }
+
+        if (json.data[0] == null) {
+          reject(`:x: Streamer ${username} was not found, Please try again.`);
+          return;
+        }
+        resolve(json);
+      } catch (e) {
+        console.error(e);
+        reject('There was a problem fetching user info from the Twitch API');
+      }
+    });
+  }
+
+  // streamInfo.data[0]
+  static getStream(token, client_id, userID) {
+    return new Promise(async function fetchStream(resolve, reject) {
+      try {
+        const response = await fetch(
+          `https://api.twitch.tv/helix/streams?user_id=${userID}`,
+          {
+            method: 'GET',
+            headers: {
+              'client-id': `${client_id}`,
+              Authorization: `Bearer ${token}`
+            }
+          }
+        );
+        const json = await response.json();
+        resolve(json);
+      } catch (e) {
+        console.error(e);
+        reject('There was a problem fetching stream info from the Twitch API');
+      }
+    });
+  }
+
+  // gameInfo.data[0]
+  static getGames(token, client_id, game_id) {
+    return new Promise(async function fetchGames(resolve, reject) {
+      try {
+        const response = await fetch(
+          `https://api.twitch.tv/helix/games?id=${game_id}`,
+          {
+            method: 'GET',
+            headers: {
+              'client-id': `${client_id}`,
+              Authorization: `Bearer ${token}`
+            }
+          }
+        );
+        const json = await response.json();
+        resolve(json);
+      } catch (e) {
+        console.error(e);
+        reject('There was a problem fetching stream info from the Twitch API');
+      }
+    });
+  }
+};


### PR DESCRIPTION
This is what #382's Files were supposed to look like (07a5b10) but would never save correctly when I commited from my main account 

adds instructions on how to get the twitch features set up(client id/ secret key)

-Below is just copied from OP
Reworked all Twitch Features to reference a `twitch-api.js` for the situation where a user wants one feature and not both. 
This thought kept me up at night after twitch announcer was merged

also Fixes the Box Art for Online Embed in `twitchstatus.js` where previously only 5 games that could get passed the 'jpg' filter in the `setThumbnail()`

![image](https://user-images.githubusercontent.com/12632936/102725243-01c6aa00-42db-11eb-8dfb-4258f8f03c38.png)

the console message that twitch key is missing in `config.json` was changed to reference all twitch related features instead of just `twitchstatus`
```
INFO: Twitch Commands removed from the list.
Make sure you have "twitchClientID" and "twitchClientSecret" in your config.json to use Twitch Features
```

I apologize for so many changes so quickly
it lets me add to the 'twitch-api.js' file for future features if any other calls to Twitch are needed (without the need to make 'twitchstatus.js' more complicated)

- Notes on test situations: 
If you are set up for `commandState true` and `!disable twitchstatus`  then twitch announcer will give an error when used in that server.
If 'twitchstatus.js' was removed then Twitch Announcer can't be used gives an error in all servers.

Much Love
-Bacon