### PR TITLE
config.json based command list + Update move.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,27 @@
 
 Make a config.json file in the root directory of the project and add:
 
+- Minimum
 ```
 {
   "prefix": "!",
   "discord_owner_id": "Your-Discord-ID",
   "token": "Your-Bot-Token",
+  "youtubeAPI": "youtube-api-key"
+}
+```
+
+- Full Command List
+```
+{
+  "prefix": "!",
+  "discord_owner_id": "Your-Discord-ID",
+  "token": "Your-Bot-Token",
+  "youtubeAPI": "youtube-api-key",
+  "geniusLyricsAPI": "genius-api-key",
   "tenorAPI": "tenor-API-key",
   "newsAPI": "news-api-key",
-  "youtubeAPI": "youtube-api-key",
   "yandexAPI": "yandex-api-key",
-  "geniusLyricsAPI": "genius-api-key",
   "twitchClientID": "Your-Client-ID",
   "twitchClientSecret": "Your-Client-Secret"
 }

--- a/commands/gifs/animegif.js
+++ b/commands/gifs/animegif.js
@@ -2,6 +2,9 @@ const fetch = require('node-fetch');
 const { tenorAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
 
+// Skips loading if not found in config.json
+if (!tenorAPI) return;
+
 module.exports = class AnimegifCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/gifs/gif.js
+++ b/commands/gifs/gif.js
@@ -2,6 +2,9 @@ const fetch = require('node-fetch');
 const { tenorAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
 
+// Skips loading if not found in config.json
+if (!tenorAPI) return;
+
 module.exports = class GifCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -9,7 +9,7 @@ const {
 } = require('../../config.json');
 
 // Skips loading if not found in config.json
-if (twitchClientID == null || twitchClientSecret == null) return;
+if (!twitchClientID || !twitchClientSecret) return;
 
 module.exports = class TwitchAnnouncerSettingsCommand extends Command {
   constructor(client) {

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -11,7 +11,7 @@ const {
 } = require('../../config.json');
 
 // Skips loading if not found in config.json
-if (twitchClientID == null || twitchClientSecret == null) return;
+if (!twitchClientID || !twitchClientSecret) return;
 
 module.exports = class TwitchAnnouncerCommand extends Command {
   constructor(client) {

--- a/commands/music/lyrics.js
+++ b/commands/music/lyrics.js
@@ -5,6 +5,9 @@ const fetch = require('node-fetch');
 const cheerio = require('cheerio');
 const { geniusLyricsAPI } = require('../../config.json');
 
+// Skips loading if not found in config.json
+if (!geniusLyricsAPI) return;
+
 module.exports = class LyricsCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/music/move.js
+++ b/commands/music/move.js
@@ -8,6 +8,7 @@ module.exports = class MoveSongCommand extends Command {
       aliases: ['m', 'movesong'],
       description: 'Move song to a desired position in queue!',
       group: 'music',
+      guildOnly: true,
       throttling: {
         usages: 1,
         duration: 5

--- a/commands/other/cat.js
+++ b/commands/other/cat.js
@@ -2,6 +2,9 @@ const fetch = require('node-fetch');
 const { tenorAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
 
+// Skips loading if not found in config.json
+if (!tenorAPI) return;
+
 module.exports = class CatCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/other/dog.js
+++ b/commands/other/dog.js
@@ -1,7 +1,9 @@
-  
 const fetch = require('node-fetch');
 const { tenorAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
+
+// Skips loading if not found in config.json
+if (!tenorAPI) return;
 
 module.exports = class DogCommand extends Command {
   constructor(client) {

--- a/commands/other/translate.js
+++ b/commands/other/translate.js
@@ -4,6 +4,9 @@ const { yandexAPI } = require('../../config.json');
 const ISO6391 = require('iso-639-1');
 const fetch = require('node-fetch');
 
+// Skips loading if not found in config.json
+if (!yandexAPI) return;
+
 module.exports = class TranslateCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/other/twitchstatus.js
+++ b/commands/other/twitchstatus.js
@@ -6,7 +6,7 @@ const Canvas = require('canvas');
 const probe = require('probe-image-size');
 
 // Skips loading if not found in config.json
-if (twitchClientID == null || twitchClientSecret == null) return;
+if (!twitchClientID || !twitchClientSecret) return;
 
 module.exports = class TwitchStatusCommand extends Command {
   constructor(client) {
@@ -32,12 +32,11 @@ module.exports = class TwitchStatusCommand extends Command {
   }
 
   async run(message, { textRaw }) {
-    
     // Twitch Section
     const scope = 'user:read:email';
     const textFiltered = textRaw.replace(/https\:\/\/twitch.tv\//g, '');
     let access_token;
-    
+
     try {
       access_token = await TwitchAPI.getToken(
         twitchClientID,
@@ -61,7 +60,7 @@ module.exports = class TwitchStatusCommand extends Command {
     }
 
     const user_id = user.data[0].id;
-    
+
     try {
       var streamInfo = await TwitchAPI.getStream(
         access_token,
@@ -108,7 +107,7 @@ module.exports = class TwitchStatusCommand extends Command {
       message.say(offlineEmbed);
       return;
     }
-    
+
     // Box Art Recreation
     try {
       var gameInfo = await TwitchAPI.getGames(

--- a/commands/other/world-news.js
+++ b/commands/other/world-news.js
@@ -3,6 +3,9 @@ const fetch = require('node-fetch');
 const { newsAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
 
+// Skips loading if not found in config.json
+if (!newsAPI) return;
+
 module.exports = class GlobalNewsCommand extends Command {
   constructor(client) {
     super(client, {

--- a/commands/other/ynet-news.js
+++ b/commands/other/ynet-news.js
@@ -3,6 +3,9 @@ const { newsAPI } = require('../../config.json');
 const { Command } = require('discord.js-commando');
 const fetch = require('node-fetch');
 
+// Skips loading if not found in config.json
+if (!newsAPI) return;
+
 module.exports = class YnetNewsCommand extends Command {
   constructor(client) {
     super(client, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,7 +1178,7 @@
       }
     },
     "discord.js-commando": {
-      "version": "github:discordjs/Commando#198d7604e3725ee88dceab9b5f296edb1b7580a5",
+      "version": "github:discordjs/Commando#3cd5f8c763f0d644432eeba59f831eb942de7bd4",
       "from": "github:discordjs/Commando",
       "requires": {
         "common-tags": "^1.8.0",
@@ -4592,9 +4592,9 @@
       "dev": true
     },
     "ytdl-core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.4.0.tgz",
-      "integrity": "sha512-9ceiEL5iM0OULciBySzoZA91YyxqnlHd3aeqf5r3S8rNgPGLDn11fJeEsKO1jQ1t/eYO1dK4zTkrIH7S497cyg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.4.3.tgz",
+      "integrity": "sha512-0GexY2dMk0pvIE0UAB5GPiyaNjiawqDi5eUCUHW7CP1ZNyEco8Lct8/3AsI6aO0EQLGK774ocDvWxOE7W0qrTg==",
       "requires": {
         "m3u8stream": "^0.8.3",
         "miniget": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "probe-image-size": "^6.0.0",
     "quick.db": "^7.1.3",
     "simple-youtube-api": "^5.2.1",
-    "ytdl-core": "^4.4.0"
+    "ytdl-core": "^4.4.3"
   },
   "devDependencies": {
     "@getify/eslint-plugin-proper-arrows": "^8.0.1",

--- a/resources/twitch/twitch-api.js
+++ b/resources/twitch/twitch-api.js
@@ -2,13 +2,9 @@ const fetch = require('node-fetch');
 const { twitchClientID, twitchClientSecret } = require('../../config.json');
 
 // Skips loading if not found in config.json
-if (twitchClientID == null || twitchClientSecret == null)
-  return console.log(
-    'INFO: Twitch Features were removed from the list. \nMake sure you have "twitchClientID" and "twitchClientSecret" in your config.json to use Twitch Features '
-  );
+if (!twitchClientID || !twitchClientSecret) return;
 
 module.exports = class TwitchAPI {
-  
   //Access Token is valid for 24 Hours
   static getToken(twitchClientID, twitchClientSecret, scope) {
     return new Promise(async function fetchToken(resolve, reject) {


### PR DESCRIPTION
Allows Master-Bot command list adjust to what API is listed in the config.json for the following API's only
```
  "geniusLyricsAPI": "genius-api-key",
  "tenorAPI": "tenor-API-key",
  "newsAPI": "news-api-key",
  "yandexAPI": "yandex-api-key",
  "twitchClientID": "Your-Client-ID",
  "twitchClientSecret": "Your-Client-Secret"
```

Removes the `Info: Twitch Commands removed from list` message(cleaner launch)

Edits README.md to show a minimum and a full config.json

Adds `guildOnly: true` to move.js (showed up in command list when `help` was DM'd to Master-Bot)

Much Love
-Bacon