### PR TITLE
Typos and formatting for the Welcome Message Feature Set

### DIFF
--- a/commands/guild/welcome-message-settings.js
+++ b/commands/guild/welcome-message-settings.js
@@ -3,7 +3,7 @@ const { Command } = require('discord.js-commando');
 const db = require('quick.db');
 const { prefix } = require('../../config.json');
 
-module.exports = class WecomeSettingsCommand extends Command {
+module.exports = class WelcomeSettingsCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'welcome-message-settings',
@@ -119,7 +119,6 @@ module.exports = class WecomeSettingsCommand extends Command {
     }
   ) {
     let destinationChannel;
-    
 
     //Grab DB 1 Get
     const DBInfo = db.get(
@@ -163,10 +162,10 @@ module.exports = class WecomeSettingsCommand extends Command {
 
     //Swap if in the incorrect order
     if (imageHeight > imageWidth) {
-        imageWidth = imageHeight;
-        imageHeight = imageWidth;
-     }
-    
+      imageWidth = imageHeight;
+      imageHeight = imageWidth;
+    }
+
     //Save to DB 1 set
     db.set(`${message.member.guild.id}.serverSettings.welcomeMsg`, {
       destination: destination,
@@ -204,8 +203,8 @@ module.exports = class WecomeSettingsCommand extends Command {
         message.member.user.displayAvatarURL()
       )
       .setTimestamp();
-    
-    //Shows Local wallpaper when in Default 
+
+    //Shows Local wallpaper when in Default
     if (wallpaperURL == './resources/welcome/wallpaper.jpg') {
       const attachment = new MessageAttachment(
         '././resources/welcome/wallpaper.jpg'

--- a/commands/guild/welcome-message.js
+++ b/commands/guild/welcome-message.js
@@ -3,7 +3,7 @@ const { Command } = require('discord.js-commando');
 const db = require('quick.db');
 const { prefix } = require('../../config.json');
 
-module.exports = class WecomeMessageCommand extends Command {
+module.exports = class WelcomeMessageCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'welcome-message',
@@ -28,12 +28,11 @@ module.exports = class WecomeMessageCommand extends Command {
 
   //DB Tally (2 enable new db) || (2 enable has DB) || (1 disable)
   run(message, { choice }) {
-    
     // Converting choices
     if (choice.toLowerCase() == 'enable') choice = 'yes';
 
     if (choice.toLowerCase() == 'disable') choice = 'no';
-   
+
     // Save to DB 1 set
     db.set(
       `${message.member.guild.id}.serverSettings.welcomeMsg.status`,
@@ -41,15 +40,13 @@ module.exports = class WecomeMessageCommand extends Command {
     );
 
     if (choice.toLowerCase() == 'yes') {
-    
       // Grab DB 1 get
       const DBInfo = db.get(
         `${message.member.guild.id}.serverSettings.welcomeMsg`
       );
-     
+
       // DB check
       if (DBInfo.cmdUsed == null) {
-        
         // Saving Defaults if none are present
         db.set(`${message.member.guild.id}.serverSettings.welcomeMsg`, {
           destination: 'direct message',
@@ -64,11 +61,11 @@ module.exports = class WecomeMessageCommand extends Command {
           timeStamp: message.createdAt,
           cmdUsed: message.content
         });
-        
+
         const attachment = new MessageAttachment(
           '././resources/welcome/wallpaper.jpg'
         );
-        
+
         // Embed for New DB situation
         const embed = new MessageEmbed()
           .setTitle(
@@ -82,7 +79,7 @@ module.exports = class WecomeMessageCommand extends Command {
           .addField('Message Destination', 'direct message')
           .addField(`Title`, 'default')
           .addField(`Upper Text`, 'default')
-          .addField(`Lower Text`, 'defualt')
+          .addField(`Lower Text`, 'default')
           .addField(`Image Size`, 700 + ` X ` + 250)
           .addField(`Image Path`, './resources/welcome/wallpaper.jpg')
           .setColor('#420626')
@@ -95,9 +92,7 @@ module.exports = class WecomeMessageCommand extends Command {
           );
 
         return message.say(embed);
-      
       } else {
-        
         // Report Back settings from DB
         const embed = new MessageEmbed()
           .setTitle(
@@ -131,7 +126,7 @@ module.exports = class WecomeMessageCommand extends Command {
         return message.say(embed);
       }
     }
-    
+
     // Report Settings are Disabled
     if (choice.toLowerCase() == 'no')
       message.say(

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ client.on('guildMemberAdd', async member => {
 
       return ctx.font;
     };
-    
+
     // Customizable Welcome Image Options
     var canvas = await Canvas.createCanvas(
       welcomeMsgSettings.imageWidth,
@@ -139,7 +139,6 @@ client.on('guildMemberAdd', async member => {
         canvas.height / 3.5
       );
     } else {
-      
       // Upper Text Options DB
       ctx.font = '26px Open Sans Light'; // if the font register changed this needs to match the family Name on line 65
       ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
@@ -155,7 +154,7 @@ client.on('guildMemberAdd', async member => {
         canvas.height / 3.5
       );
     }
-   
+
     // Lower Text Options Defaults
     if (welcomeMsgSettings.bottomImageText == 'default') {
       ctx.font = applyText(canvas, `${member.displayName}!`);
@@ -187,7 +186,7 @@ client.on('guildMemberAdd', async member => {
         canvas.height / 1.8
       );
     }
-    
+
     // Avatar Shape Options
     ctx.beginPath();
     ctx.arc(125, 125, 100, 0, Math.PI * 2, true); // Shape option (circle)
@@ -205,7 +204,7 @@ client.on('guildMemberAdd', async member => {
       canvas.toBuffer(),
       'welcome-image.png'
     );
-    
+
     // Welcome Embed Report
     var embed = new MessageEmbed()
       .setColor(`RANDOM`)
@@ -218,8 +217,8 @@ client.on('guildMemberAdd', async member => {
         `:speech_balloon: Hey ${member.displayName}, You look new to ${member.guild.name}!` //<-- didn't play nice being stored in DB -Default
       );
     } else embed.setTitle(welcomeMsgSettings.embedTitle);
-    
-    // Sends a DM if set to or if destenation is not present in DB(pre channel option users)
+
+    // Sends a DM if set to or if destination is not present in DB(pre channel option users)
     if (
       welcomeMsgSettings.destination == 'direct message' ||
       !welcomeMsgSettings.destination
@@ -229,7 +228,7 @@ client.on('guildMemberAdd', async member => {
       } catch {
         console.log(`${member.user.username}'s dms are private`);
       }
-    
+
     // Sends to assigned Channel from DB
     if (welcomeMsgSettings.destination != 'direct message') {
       const channel = member.guild.channels.cache.find(


### PR DESCRIPTION
Noticed when looking into #455
this doesn't directly fix that issue

3 typo's
`WecomeSettingsCommand` > `WelcomeSettingsCommand` 
`WecomeMessageCommand` > `WelcomeMessageCommand`

`.addField(`Lower Text`, 'defualt')` > `.addField(`Lower Text`, 'default')`



