### PR TITLE
adds a Game Search Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Make a config.json file in the root directory of the project and add:
   "tenorAPI": "tenor-API-key",
   "newsAPI": "news-api-key",
   "twitchClientID": "Your-Client-ID",
-  "twitchClientSecret": "Your-Client-Secret"
+  "twitchClientSecret": "Your-Client-Secret",
+  "rawgAPI": "rawg-api-key"
+
 }
 ```
 
@@ -105,6 +107,7 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 | !twitchstatus     | A quick check to see if a streamer is currently online. or to give a shout-out a fellow streamer                                                                   | !twitchstatus MasterBot or !tso MasterBot                                    |
 | !tv-show-search   | Search for Tv shows with a keyword                                                                                                                                 | !tv-show-search Duck                                                         |
 | !nickname         | Sets the selected member's nickname with the provided nickname                                                                                                     | !nickname @Master-Bot Master                                                 |
+| !game-search      | Search for game information                                                                                                                                        | !game-search super metroid                                                   |
 
 - Gifs
 
@@ -138,6 +141,8 @@ If you are not cloning this repo, make sure your dependencies versions are the s
 [Get a Genius API key here](https://genius.com/api-clients/new)
 
 [How to get a Twitch API Key](https://github.com/Bacon-Fixation/Master-Bot/wiki/Getting-Your-Twitch-API-Info)
+
+[Get a rawg API key here](https://rawg.io/apidocs)
 
 [Installing node.js on debian](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-node-js-application-for-production-on-debian-9)
 

--- a/commands/other/game-search.js
+++ b/commands/other/game-search.js
@@ -25,150 +25,193 @@ module.exports = class GameSearchCommand extends Command {
   }
 
   async run(message, { gameQuery }) {
-    let gameTitleFiltered = gameQuery
+    const gameTitleFiltered = gameQuery
       .replace(/ /g, '-')
       .replace(/'/g, '')
       .toLowerCase();
 
     // using this link it provides all the info, instead of using search
-    let initialGame = await fetch(
-      `https://api.rawg.io/api/games/${gameTitleFiltered}?key=${rawgAPI}`
-    );
-    let response = await initialGame.json();
-
-    if (response.detail === 'Not found. ') {
-      message.channel.send(`:x: Error: ${gameQuery} was not found`);
+    try {
+      var response = await getGameDetails(gameTitleFiltered);
+    } catch (error) {
+      message.channel.send(error);
       return;
     }
-    if (response.redirect) {
-      initialGame = await fetch(
-        `https://api.rawg.io/api/games/${response.slug}?key=${rawgAPI}`
+
+    try {
+      let releaseDate;
+      if (response.tba) {
+        releaseDate = 'TBA';
+      } else if (response.released == null) {
+        releaseDate = 'None Listed.';
+      } else {
+        releaseDate = response.released;
+      }
+
+      let esrbRating;
+      if (response.esrb_rating == null) {
+        esrbRating = 'None Listed.';
+      } else {
+        esrbRating = response.esrb_rating.name;
+      }
+
+      let userRating;
+      if (response.rating == null) {
+        userRating = 'None Listed.';
+      } else {
+        userRating = response.rating + '/5';
+      }
+
+      const embedArray = [
+        // Page 1
+        new MessageEmbed()
+          .setDescription(
+            '**Game Description**\n' +
+              response.description_raw.slice(0, 2000) +
+              '...'
+          )
+          .addField('Released', releaseDate, true)
+          .addField('ESRB Rating', esrbRating, true)
+          .addField('Score', userRating, true)
+      ];
+
+      const developerArray = [];
+      if (response.developers.length > 0) {
+        for (let i = 0; i < response.developers.length; ++i) {
+          developerArray.push(response.developers[i].name);
+        }
+      } else {
+        developerArray.push('None Listed.');
+      }
+
+      const publisherArray = [];
+      if (response.publishers.length > 0) {
+        for (let i = 0; i < response.publishers.length; ++i) {
+          publisherArray.push(response.publishers[i].name);
+        }
+      } else {
+        publisherArray.push('None Listed.');
+      }
+
+      const platformArray = [];
+      if (response.platforms.length > 0) {
+        for (let i = 0; i < response.platforms.length; ++i) {
+          platformArray.push(response.platforms[i].platform.name);
+        }
+      } else {
+        platformArray.push('None Listed.');
+      }
+
+      const genreArray = [];
+      if (response.genres.length > 0) {
+        for (let i = 0; i < response.genres.length; ++i) {
+          genreArray.push(response.genres[i].name);
+        }
+      } else {
+        genreArray.push('None Listed.');
+      }
+
+      const retailerArray = [];
+      if (response.stores.length > 0) {
+        for (let i = 0; i < response.stores.length; ++i) {
+          retailerArray.push(
+            `[${response.stores[i].store.name}](${response.stores[i].url})`
+          );
+        }
+      } else {
+        retailerArray.push('None Listed.');
+      }
+
+      embedArray.push(
+        // Page 2
+        new MessageEmbed()
+          // Row 1
+          .addField(
+            'Developer(s)',
+            developerArray.toString().replace(/,/g, ', '),
+            true
+          )
+          .addField(
+            'Publisher(s)',
+            publisherArray.toString().replace(/,/g, ', '),
+            true
+          )
+          .addField(
+            'Platform(s)',
+            platformArray.toString().replace(/,/g, ', '),
+            true
+          )
+          // Row 2
+          .addField('Genre(s)', genreArray.toString().replace(/,/g, ', '), true)
+          .addField(
+            'Retailer(s)',
+            retailerArray
+              .toString()
+              .replace(/,/g, ', ')
+              .replace(/`/g, '')
+          )
       );
-      response = await initialGame.json();
-    }
 
-    let releaseDate;
-    if (response.tba) {
-      releaseDate = 'TBA';
-    } else if (response.released == null) {
-      releaseDate = 'None Listed.';
-    } else {
-      releaseDate = response.released;
-    }
-
-    let esrbRating;
-    if (response.esrb_rating == null) {
-      esrbRating = 'None Listed.';
-    } else {
-      esrbRating = response.esrb_rating.name;
-    }
-
-    let userRating;
-    if (response.rating == null) {
-      userRating = 'None Listed.';
-    } else {
-      userRating = response.rating + '/5';
-    }
-
-    const embedArray = [
-      // Page 1
-      new MessageEmbed()
-        .setDescription(
-          '**Game Description**\n' +
-            response.description_raw.slice(0, 2000) +
-            '...'
-        )
-        .addField('Released', releaseDate, true)
-        .addField('ESRB Rating', esrbRating, true)
-        .addField('Score', userRating, true)
-    ];
-
-    const developerArray = [];
-    if (response.developers.length > 0) {
-      for (let i = 0; i < response.developers.length; ++i) {
-        developerArray.push(response.developers[i].name);
+      const embed = new Pagination.Embeds()
+        .setArray(embedArray)
+        .setAuthorizedUsers([message.author.id])
+        .setChannel(message.channel)
+        .setTitle(response.name)
+        .setColor(`#b5b5b5`);
+      if (response.background_image) {
+        embed.setThumbnail(response.background_image);
       }
-    } else {
-      developerArray.push('None Listed.');
+      embed.build();
+    } catch (error) {
+      message.reply(':x: Something went wrong with your request.');
+      console.log(error);
     }
 
-    const publisherArray = [];
-    if (response.publishers.length > 0) {
-      for (let i = 0; i < response.publishers.length; ++i) {
-        publisherArray.push(response.publishers[i].name);
-      }
-    } else {
-      publisherArray.push('None Listed.');
-    }
+    function getGameDetails(query) {
+      return new Promise(async function(resolve, reject) {
+        const url = `https://api.rawg.io/api/games/${query}?key=${rawgAPI}`;
+        try {
+          const body = await fetch(url);
+          if (body.status == `429`) {
+            reject(
+              ':x: Rate Limit exceeded. Please try again in a few minutes.'
+            );
+          }
+          if (body.status == `503`) {
+            reject(
+              ':x: The service is currently unavailable. Please try again later.'
+            );
+          }
+          if (body.status == '404') {
+            reject(`:x: Error: ${query} was not found`);
+          }
+          if (body.status !== 200) {
+            reject(
+              ':x: There was a problem getting data from the API, make sure you entered a valid game tittle'
+            );
+          }
 
-    const platformArray = [];
-    if (response.platforms.length > 0) {
-      for (let i = 0; i < response.platforms.length; ++i) {
-        platformArray.push(response.platforms[i].platform.name);
-      }
-    } else {
-      platformArray.push('None Listed.');
+          let data = await body.json();
+          if (data.redirect) {
+            const redirect = await fetch(
+              `https://api.rawg.io/api/games/${body.slug}?key=${rawgAPI}`
+            );
+            data = await redirect.json();
+          }
+          // 'id' is the only value that must be present to all valid queries
+          if (!data.id) {
+            reject(
+              ':x: There was a problem getting data from the API, make sure you entered a valid game title'
+            );
+          }
+          resolve(data);
+        } catch (e) {
+          console.error(e);
+          reject(
+            'There was a problem getting data from the API, make sure you entered a valid game title'
+          );
+        }
+      });
     }
-
-    const genreArray = [];
-    if (response.genres.length > 0) {
-      for (let i = 0; i < response.genres.length; ++i) {
-        genreArray.push(response.genres[i].name);
-      }
-    } else {
-      genreArray.push('None Listed.');
-    }
-
-    const retailerArray = [];
-    if (response.stores.length > 0) {
-      for (let i = 0; i < response.stores.length; ++i) {
-        retailerArray.push(
-          `[${response.stores[i].store.name}](${response.stores[i].url})`
-        );
-      }
-    } else {
-      retailerArray.push('None Listed.');
-    }
-
-    embedArray.push(
-      // Page 2
-      new MessageEmbed()
-        // Row 1
-        .addField(
-          'Developer(s)',
-          developerArray.toString().replace(/,/g, ', '),
-          true
-        )
-        .addField(
-          'Publisher(s)',
-          publisherArray.toString().replace(/,/g, ', '),
-          true
-        )
-        .addField(
-          'Platform(s)',
-          platformArray.toString().replace(/,/g, ', '),
-          true
-        )
-        // Row 2
-        .addField('Genre(s)', genreArray.toString().replace(/,/g, ', '), true)
-        .addField(
-          'Retailer(s)',
-          retailerArray
-            .toString()
-            .replace(/,/g, ', ')
-            .replace(/`/g, '')
-        )
-    );
-
-    const embed = new Pagination.Embeds()
-      .setArray(embedArray)
-      .setAuthorizedUsers([message.author.id])
-      .setChannel(message.channel)
-      .setTitle(response.name)
-      .setColor(`#b5b5b5`);
-    if (response.background_image) {
-      embed.setThumbnail(response.background_image);
-    }
-    embed.build();
   }
 };

--- a/commands/other/game-search.js
+++ b/commands/other/game-search.js
@@ -1,0 +1,174 @@
+const { Command } = require('discord.js-commando');
+const { MessageEmbed } = require('discord.js');
+const Pagination = require('discord-paginationembed');
+const fetch = require('node-fetch');
+const { rawgAPI } = require('../../config.json');
+
+if (!rawgAPI) return;
+
+module.exports = class GameSearchCommand extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'game-search',
+      aliases: ['gs'],
+      memberName: 'game-search',
+      group: 'other',
+      description: 'Display game information ',
+      args: [
+        {
+          key: 'gameQuery',
+          prompt: 'What game are you looking for?',
+          type: 'string'
+        }
+      ]
+    });
+  }
+
+  async run(message, { gameQuery }) {
+    let gameTitleFiltered = gameQuery
+      .replace(/ /g, '-')
+      .replace(/'/g, '')
+      .toLowerCase();
+
+    // using this link it provides all the info, instead of using search
+    let initialGame = await fetch(
+      `https://api.rawg.io/api/games/${gameTitleFiltered}?key=${rawgAPI}`
+    );
+    let response = await initialGame.json();
+
+    if (response.detail === 'Not found. ') {
+      message.channel.send(`:x: Error: ${gameQuery} was not found`);
+      return;
+    }
+    if (response.redirect) {
+      initialGame = await fetch(
+        `https://api.rawg.io/api/games/${response.slug}?key=${rawgAPI}`
+      );
+      response = await initialGame.json();
+    }
+
+    let releaseDate;
+    if (response.tba) {
+      releaseDate = 'TBA';
+    } else if (response.released == null) {
+      releaseDate = 'None Listed.';
+    } else {
+      releaseDate = response.released;
+    }
+
+    let esrbRating;
+    if (response.esrb_rating == null) {
+      esrbRating = 'None Listed.';
+    } else {
+      esrbRating = response.esrb_rating.name;
+    }
+
+    let userRating;
+    if (response.rating == null) {
+      userRating = 'None Listed.';
+    } else {
+      userRating = response.rating + '/5';
+    }
+
+    const embedArray = [
+      // Page 1
+      new MessageEmbed()
+        .setDescription(
+          '**Game Description**\n' +
+            response.description_raw.slice(0, 2000) +
+            '...'
+        )
+        .addField('Released', releaseDate, true)
+        .addField('ESRB Rating', esrbRating, true)
+        .addField('Score', userRating, true)
+    ];
+
+    const developerArray = [];
+    if (response.developers.length > 0) {
+      for (let i = 0; i < response.developers.length; ++i) {
+        developerArray.push(response.developers[i].name);
+      }
+    } else {
+      developerArray.push('None Listed.');
+    }
+
+    const publisherArray = [];
+    if (response.publishers.length > 0) {
+      for (let i = 0; i < response.publishers.length; ++i) {
+        publisherArray.push(response.publishers[i].name);
+      }
+    } else {
+      publisherArray.push('None Listed.');
+    }
+
+    const platformArray = [];
+    if (response.platforms.length > 0) {
+      for (let i = 0; i < response.platforms.length; ++i) {
+        platformArray.push(response.platforms[i].platform.name);
+      }
+    } else {
+      platformArray.push('None Listed.');
+    }
+
+    const genreArray = [];
+    if (response.genres.length > 0) {
+      for (let i = 0; i < response.genres.length; ++i) {
+        genreArray.push(response.genres[i].name);
+      }
+    } else {
+      genreArray.push('None Listed.');
+    }
+
+    const retailerArray = [];
+    if (response.stores.length > 0) {
+      for (let i = 0; i < response.stores.length; ++i) {
+        retailerArray.push(
+          `[${response.stores[i].store.name}](${response.stores[i].url})`
+        );
+      }
+    } else {
+      retailerArray.push('None Listed.');
+    }
+
+    embedArray.push(
+      // Page 2
+      new MessageEmbed()
+        // Row 1
+        .addField(
+          'Developer(s)',
+          developerArray.toString().replace(/,/g, ', '),
+          true
+        )
+        .addField(
+          'Publisher(s)',
+          publisherArray.toString().replace(/,/g, ', '),
+          true
+        )
+        .addField(
+          'Platform(s)',
+          platformArray.toString().replace(/,/g, ', '),
+          true
+        )
+        // Row 2
+        .addField('Genre(s)', genreArray.toString().replace(/,/g, ', '), true)
+        .addField(
+          'Retailer(s)',
+          retailerArray
+            .toString()
+            .replace(/,/g, ', ')
+            .replace(/`/g, '')
+        )
+    );
+
+    const embed = new Pagination.Embeds()
+      .setArray(embedArray)
+      .setAuthorizedUsers([message.author.id])
+      .setChannel(message.channel)
+      .setTitle(response.name)
+      .setColor(`#b5b5b5`);
+    if (response.background_image) {
+      embed.setThumbnail(response.background_image);
+    }
+    embed.build();
+  }
+};

--- a/commands/other/game-search.js
+++ b/commands/other/game-search.js
@@ -13,7 +13,7 @@ module.exports = class GameSearchCommand extends Command {
       aliases: ['gs'],
       memberName: 'game-search',
       group: 'other',
-      description: 'Display game information ',
+      description: 'Search for game information.',
       args: [
         {
           key: 'gameQuery',

--- a/commands/other/game-search.js
+++ b/commands/other/game-search.js
@@ -38,134 +38,129 @@ module.exports = class GameSearchCommand extends Command {
       return;
     }
 
-    try {
-      let releaseDate;
-      if (response.tba) {
-        releaseDate = 'TBA';
-      } else if (response.released == null) {
-        releaseDate = 'None Listed.';
-      } else {
-        releaseDate = response.released;
-      }
-
-      let esrbRating;
-      if (response.esrb_rating == null) {
-        esrbRating = 'None Listed.';
-      } else {
-        esrbRating = response.esrb_rating.name;
-      }
-
-      let userRating;
-      if (response.rating == null) {
-        userRating = 'None Listed.';
-      } else {
-        userRating = response.rating + '/5';
-      }
-
-      const embedArray = [
-        // Page 1
-        new MessageEmbed()
-          .setDescription(
-            '**Game Description**\n' +
-              response.description_raw.slice(0, 2000) +
-              '...'
-          )
-          .addField('Released', releaseDate, true)
-          .addField('ESRB Rating', esrbRating, true)
-          .addField('Score', userRating, true)
-      ];
-
-      const developerArray = [];
-      if (response.developers.length > 0) {
-        for (let i = 0; i < response.developers.length; ++i) {
-          developerArray.push(response.developers[i].name);
-        }
-      } else {
-        developerArray.push('None Listed.');
-      }
-
-      const publisherArray = [];
-      if (response.publishers.length > 0) {
-        for (let i = 0; i < response.publishers.length; ++i) {
-          publisherArray.push(response.publishers[i].name);
-        }
-      } else {
-        publisherArray.push('None Listed.');
-      }
-
-      const platformArray = [];
-      if (response.platforms.length > 0) {
-        for (let i = 0; i < response.platforms.length; ++i) {
-          platformArray.push(response.platforms[i].platform.name);
-        }
-      } else {
-        platformArray.push('None Listed.');
-      }
-
-      const genreArray = [];
-      if (response.genres.length > 0) {
-        for (let i = 0; i < response.genres.length; ++i) {
-          genreArray.push(response.genres[i].name);
-        }
-      } else {
-        genreArray.push('None Listed.');
-      }
-
-      const retailerArray = [];
-      if (response.stores.length > 0) {
-        for (let i = 0; i < response.stores.length; ++i) {
-          retailerArray.push(
-            `[${response.stores[i].store.name}](${response.stores[i].url})`
-          );
-        }
-      } else {
-        retailerArray.push('None Listed.');
-      }
-
-      embedArray.push(
-        // Page 2
-        new MessageEmbed()
-          // Row 1
-          .addField(
-            'Developer(s)',
-            developerArray.toString().replace(/,/g, ', '),
-            true
-          )
-          .addField(
-            'Publisher(s)',
-            publisherArray.toString().replace(/,/g, ', '),
-            true
-          )
-          .addField(
-            'Platform(s)',
-            platformArray.toString().replace(/,/g, ', '),
-            true
-          )
-          // Row 2
-          .addField('Genre(s)', genreArray.toString().replace(/,/g, ', '), true)
-          .addField(
-            'Retailer(s)',
-            retailerArray
-              .toString()
-              .replace(/,/g, ', ')
-              .replace(/`/g, '')
-          )
-      );
-
-      const embed = new Pagination.Embeds()
-        .setArray(embedArray)
-        .setAuthorizedUsers([message.author.id])
-        .setChannel(message.channel)
-        .setTitle(response.name)
-        .setColor(`#b5b5b5`);
-      if (response.background_image) {
-        embed.setThumbnail(response.background_image);
-      }
-      embed.build();
-    } catch (error) {
-      message.reply(':x: Something went wrong with your request.');
-      console.log(error);
+    let releaseDate;
+    if (response.tba) {
+      releaseDate = 'TBA';
+    } else if (response.released == null) {
+      releaseDate = 'None Listed.';
+    } else {
+      releaseDate = response.released;
     }
+
+    let esrbRating;
+    if (response.esrb_rating == null) {
+      esrbRating = 'None Listed.';
+    } else {
+      esrbRating = response.esrb_rating.name;
+    }
+
+    let userRating;
+    if (response.rating == null) {
+      userRating = 'None Listed.';
+    } else {
+      userRating = response.rating + '/5';
+    }
+
+    const embedArray = [
+      // Page 1
+      new MessageEmbed()
+        .setDescription(
+          '**Game Description**\n' +
+            response.description_raw.slice(0, 2000) +
+            '...'
+        )
+        .addField('Released', releaseDate, true)
+        .addField('ESRB Rating', esrbRating, true)
+        .addField('Score', userRating, true)
+    ];
+
+    const developerArray = [];
+    if (response.developers.length > 0) {
+      for (let i = 0; i < response.developers.length; ++i) {
+        developerArray.push(response.developers[i].name);
+      }
+    } else {
+      developerArray.push('None Listed.');
+    }
+
+    const publisherArray = [];
+    if (response.publishers.length > 0) {
+      for (let i = 0; i < response.publishers.length; ++i) {
+        publisherArray.push(response.publishers[i].name);
+      }
+    } else {
+      publisherArray.push('None Listed.');
+    }
+
+    const platformArray = [];
+    if (response.platforms.length > 0) {
+      for (let i = 0; i < response.platforms.length; ++i) {
+        platformArray.push(response.platforms[i].platform.name);
+      }
+    } else {
+      platformArray.push('None Listed.');
+    }
+
+    const genreArray = [];
+    if (response.genres.length > 0) {
+      for (let i = 0; i < response.genres.length; ++i) {
+        genreArray.push(response.genres[i].name);
+      }
+    } else {
+      genreArray.push('None Listed.');
+    }
+
+    const retailerArray = [];
+    if (response.stores.length > 0) {
+      for (let i = 0; i < response.stores.length; ++i) {
+        retailerArray.push(
+          `[${response.stores[i].store.name}](${response.stores[i].url})`
+        );
+      }
+    } else {
+      retailerArray.push('None Listed.');
+    }
+
+    embedArray.push(
+      // Page 2
+      new MessageEmbed()
+        // Row 1
+        .addField(
+          'Developer(s)',
+          developerArray.toString().replace(/,/g, ', '),
+          true
+        )
+        .addField(
+          'Publisher(s)',
+          publisherArray.toString().replace(/,/g, ', '),
+          true
+        )
+        .addField(
+          'Platform(s)',
+          platformArray.toString().replace(/,/g, ', '),
+          true
+        )
+        // Row 2
+        .addField('Genre(s)', genreArray.toString().replace(/,/g, ', '), true)
+        .addField(
+          'Retailer(s)',
+          retailerArray
+            .toString()
+            .replace(/,/g, ', ')
+            .replace(/`/g, '')
+        )
+    );
+
+    const embed = new Pagination.Embeds()
+      .setArray(embedArray)
+      .setAuthorizedUsers([message.author.id])
+      .setChannel(message.channel)
+      .setTitle(response.name)
+      .setColor(`#b5b5b5`);
+    if (response.background_image) {
+      embed.setThumbnail(response.background_image);
+    }
+    embed.build();
 
     function getGameDetails(query) {
       return new Promise(async function(resolve, reject) {


### PR DESCRIPTION
requires an API Key from https://rawg.io/apidocs 
and `"rawgAPI": "API Key"` added to config.json

if `rawgAPI` is not present inside config.json then the game-search command is disabled automatically

Example `!game-search super metroid`
![image](https://user-images.githubusercontent.com/12632936/115580864-1ae16680-a28d-11eb-992b-c7cce148fb29.png)

![image](https://user-images.githubusercontent.com/12632936/115581187-63991f80-a28d-11eb-8d94-1f71ce95ee07.png)


- Limits
Free accounts have a 20k calls per month

- Notes
I held onto this for about a month while rawg.io was changing the API to require a key to use
they patched the work-around I was using previously :D
it didn't require an API Key when I started making this command

Much Love
-Bacon

