### PR TITLE
Fix removing last song in queue

### DIFF
--- a/commands/music/remove.js
+++ b/commands/music/remove.js
@@ -19,7 +19,7 @@ module.exports = class RemoveSongCommand extends Command {
     });
   }
   run(message, { songNumber }) {
-    if (songNumber < 1 || songNumber >= message.guild.musicData.queue.length) {
+    if (songNumber < 1 || songNumber > message.guild.musicData.queue.length) {
       message.reply(':x: Please enter a valid song number!');
       return;
     }


### PR DESCRIPTION
Right now, you can't remove the last song in the queue. The current check has an equality, which means that if the queue has 5 elements and you try to remove song number 5, since 5==5 it will say it's an invalid number.