### PR TITLE
Plays music.youtube links

### DIFF
--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -826,10 +826,14 @@ var interactiveEmbed = message => {
 var compose = (f, g) => x => f(g(x));
 
 var isYouTubeVideoURL = arg =>
-  arg.match(/^(http(s)?:\/\/)?(m.)?((w){3}.)?youtu(be|.be)?(\.com)?\/.+/);
+  arg.match(
+    /^(http(s)?:\/\/)?(m.)?((w){3}.)?(music.)?youtu(be|.be)?(\.com)?\/.+/
+  );
 
 var isYouTubePlaylistURL = arg =>
-  arg.match(/^https?:\/\/(www.youtube.com|youtube.com)\/playlist(.*)$/);
+  arg.match(
+    /^https?:\/\/(music.)?(www.youtube.com|youtube.com)\/playlist(.*)$/
+  );
 
 var shuffleArray = arr => {
   for (let i = arr.length - 1; i > 0; i--) {


### PR DESCRIPTION
Addressing request #547 

adds `(music.)?` to both RegExp 

handles both playlists and singles from music.youtube links

Example: `?p https://music.youtube.com/watch?v=OqEZPdmevhc&list=PLETRs3ajB8Y4cqAZdCZjeQhs_fY8I6WRS`
![image](https://user-images.githubusercontent.com/12632936/117375636-0a3c0d80-ae95-11eb-8a69-ea19b3b58968.png)


Much Love
-Bacon


