### PR TITLE
Twitch Announcer Revamp

### DIFF
--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -103,23 +103,10 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
     }
 
     //Twitch Section
-    const scope = 'user:read:email';
     const textFiltered = textRaw.replace(/https\:\/\/twitch.tv\//g, '');
-    let access_token;
-    try {
-      access_token = await TwitchAPI.getToken(
-        twitchClientID,
-        twitchClientSecret,
-        scope
-      );
-    } catch (e) {
-      message.reply(':x: ' + e);
-      return;
-    }
-
     try {
       var user = await TwitchAPI.getUserInfo(
-        access_token,
+        TwitchAPI.access_token,
         twitchClientID,
         textFiltered
       );
@@ -177,7 +164,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
         .setTimestamp();
     }
 
-    //Send Reponse
+    //Send Response
     message.channel.send(embed);
   }
 };

--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -52,7 +52,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
         {
           key: 'streamChannel',
           prompt: 'What channel would you like to announce in?',
-          type: 'string'
+          type: 'channel'
         },
         {
           key: 'timer',
@@ -88,20 +88,6 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
       return;
     }
 
-    // Search by name
-    let announcedChannel = message.guild.channels.cache.find(
-      channel => channel.name == streamChannel
-    );
-
-    // Search by id
-    if (message.guild.channels.cache.get(streamChannel))
-      announcedChannel = message.guild.channels.cache.get(streamChannel);
-
-    if (!announcedChannel) {
-      message.reply(':x: ' + streamChannel + ' could not be found.');
-      return;
-    }
-
     //Twitch Section
     const textFiltered = textRaw.replace(/https\:\/\/twitch.tv\//g, '');
     try {
@@ -120,8 +106,9 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
     Twitch_DB.set(`${message.guild.id}.twitchAnnouncer`, {
       botSay: sayMsg,
       name: user.data[0].display_name,
-      channelID: announcedChannel.id,
-      channel: announcedChannel.name,
+      id: user.data[0].id,
+      channelID: streamChannel.id,
+      channel: streamChannel.name,
       timer: timer,
       savedName: message.member.displayName,
       savedAvatar: message.author.displayAvatarURL(),
@@ -145,7 +132,7 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
       .setThumbnail(user.data[0].profile_image_url)
       .addField('Pre-Notification Message', sayMsg)
       .addField(`Streamer`, user.data[0].display_name, true)
-      .addField(`Channel`, announcedChannel.name, true)
+      .addField(`Channel`, streamChannel.name, true)
       .addField(`Checking Interval`, `***${timer}*** minute(s)`, true)
       .addField('View Counter:', user.data[0].view_count, true);
     if (user.data[0].broadcaster_type == '')

--- a/commands/guild/twitch-announcer-settings.js
+++ b/commands/guild/twitch-announcer-settings.js
@@ -106,7 +106,6 @@ module.exports = class TwitchAnnouncerSettingsCommand extends Command {
     Twitch_DB.set(`${message.guild.id}.twitchAnnouncer`, {
       botSay: sayMsg,
       name: user.data[0].display_name,
-      id: user.data[0].id,
       channelID: streamChannel.id,
       channel: streamChannel.name,
       timer: timer,

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -144,7 +144,257 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         var failedAttempts = 0;
         message.guild.twitchData.isRunning = true;
         message.guild.twitchData.Interval = setInterval(async function() {
-          await announcer();
+          const announcedChannel = message.guild.channels.cache.find(
+            channel => channel.id == DBInfo.channelID
+          );
+
+          try {
+            user = await TwitchAPI.getUserInfo(
+              TwitchAPI.access_token,
+              twitchClientID,
+              `${DBInfo.name}`
+            );
+          } catch (e) {
+            ++failedAttempts;
+            if (failedAttempts == 5) {
+              message.guild.twitchData.isRunning = false;
+              message.guild.twitchData.Interval = clearInterval(
+                message.guild.twitchData.Interval
+              );
+              message.reply(':x: Twitch Announcer has stopped!\n' + e);
+            }
+            return;
+          }
+
+          try {
+            var streamInfo = await TwitchAPI.getStream(
+              TwitchAPI.access_token,
+              twitchClientID,
+              user.data[0].id
+            );
+          } catch (e) {
+            ++failedAttempts;
+            if (failedAttempts == 5) {
+              message.guild.twitchData.isRunning = false;
+              message.guild.twitchData.Interval = clearInterval(
+                message.guild.twitchData.Interval
+              );
+              message.reply(':x: Twitch Announcer has stopped!\n' + e);
+            }
+            return;
+          }
+
+          // Set Status to Offline
+          if (
+            !streamInfo.data[0] &&
+            message.guild.twitchData.embedStatus == 'sent'
+          ) {
+            message.guild.twitchData.embedStatus = 'offline';
+          }
+          // Set Status To Online
+          if (
+            message.guild.twitchData.embedStatus != 'sent' &&
+            streamInfo.data[0]
+          ) {
+            message.guild.twitchData.embedStatus = 'online';
+          }
+
+          // Online Status
+          if (message.guild.twitchData.embedStatus == 'online') {
+            currentGame = streamInfo.data[0].game_name;
+
+            try {
+              user = await TwitchAPI.getUserInfo(
+                TwitchAPI.access_token,
+                twitchClientID,
+                `${DBInfo.name}`
+              );
+            } catch (e) {
+              ++failedAttempts;
+              if (failedAttempts == 5) {
+                message.guild.twitchData.isRunning = false;
+                message.guild.twitchData.Interval = clearInterval(
+                  message.guild.twitchData.Interval
+                );
+                message.reply(':x: Twitch Announcer has stopped!\n' + e);
+              }
+              return;
+            }
+
+            try {
+              var gameInfo = await TwitchAPI.getGames(
+                TwitchAPI.access_token,
+                twitchClientID,
+                streamInfo.data[0].game_id
+              );
+
+              var result = await probe(
+                gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
+              );
+              var canvas = Canvas.createCanvas(result.width, result.height);
+              var ctx = canvas.getContext('2d');
+              // Since the image takes time to load, you should await it
+              var background = await Canvas.loadImage(
+                gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
+              );
+              // This uses the canvas dimensions to stretch the image onto the entire canvas
+              ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
+              // Use helpful Attachment class structure to process the file for you
+              var attachment = new MessageAttachment(
+                canvas.toBuffer(),
+                'box_art.png'
+              );
+            } catch (e) {
+              ++failedAttempts;
+              if (failedAttempts == 5) {
+                message.guild.twitchData.isRunning = false;
+                message.guild.twitchData.Interval = clearInterval(
+                  message.guild.twitchData.Interval
+                );
+                message.reply(':x: Twitch Announcer has stopped!\n' + e);
+              }
+              return;
+            }
+
+            // Online Embed
+            const onlineEmbed = new MessageEmbed()
+              .setAuthor(
+                `Twitch Announcement: ${user.data[0].display_name} Online!`,
+                user.data[0].profile_image_url,
+                'https://twitch.tv/' + user.data[0].display_name
+              )
+              .setURL('https://twitch.tv/' + user.data[0].display_name)
+              .setTitle(
+                user.data[0].display_name + ' is playing ' + currentGame
+              )
+              .addField('Stream Title:', streamInfo.data[0].title)
+              .addField(
+                'Currently Playing:',
+                streamInfo.data[0].game_name,
+                true
+              )
+              .addField('Viewers:', streamInfo.data[0].viewer_count, true)
+              .setColor('#6441A4')
+              .setFooter(
+                'Stream Started',
+                'https://static.twitchcdn.net/assets/favicon-32-d6025c14e900565d6177.png' // Official icon link from Twitch.tv
+              )
+              .setImage(
+                streamInfo.data[0].thumbnail_url
+                  .replace(/{width}x{height}/g, '1280x720')
+                  .concat('?r=' + Math.floor(Math.random() * 10000 + 1)) // to ensure the image updates when refreshed
+              )
+              .setTimestamp(streamInfo.data[0].started_at)
+              .attachFiles(attachment)
+              .setThumbnail('attachment://box_art.png');
+
+            if (user.data[0].broadcaster_type == '')
+              onlineEmbed.addField('Rank:', 'BASE!', true);
+            else {
+              onlineEmbed.addField(
+                'Rank:',
+                user.data[0].broadcaster_type.toUpperCase() + '!',
+                true
+              );
+            }
+
+            // Online Send
+            try {
+              if (DBInfo.botSay.toLowerCase() != 'none') {
+                await announcedChannel.send(DBInfo.botSay),
+                  await announcedChannel.send(onlineEmbed).then(result => {
+                    embedID = result.id;
+                  });
+              } else {
+                await announcedChannel.send(onlineEmbed).then(result => {
+                  embedID = result.id;
+                });
+              }
+            } catch (error) {
+              ++failedAttempts;
+              if (failedAttempts == 5) {
+                message.reply(':x: Could not send message to channel');
+                console.log(error);
+                message.guild.twitchData.isRunning = false;
+                message.guild.twitchData.Interval = clearInterval(
+                  message.guild.twitchData.Interval
+                );
+              }
+              return;
+            }
+            // Change Embed Status
+            message.guild.twitchData.embedStatus = 'sent';
+          }
+
+          // Offline Status
+          if (message.guild.twitchData.embedStatus == 'offline') {
+            const offlineEmbed = new MessageEmbed()
+              .setAuthor(
+                `Twitch Announcement: ${user.data[0].display_name} Offline`,
+                user.data[0].profile_image_url,
+                'https://twitch.tv/' + user.data[0].display_name
+              )
+              .setTitle(
+                user.data[0].display_name + ' was playing ' + currentGame
+              )
+              .setColor('#6441A4')
+              .setTimestamp()
+              .setFooter(
+                'Stream Ended',
+                'https://static.twitchcdn.net/assets/favicon-32-d6025c14e900565d6177.png'
+              )
+              .setThumbnail('attachment://box_art.png');
+
+            // Incase the there is no Profile Description
+            if (!user.data[0].description == '') {
+              offlineEmbed.addField(
+                'Profile Description:',
+                user.data[0].description
+              );
+            }
+            offlineEmbed.addField(
+              'View Counter:',
+              user.data[0].view_count,
+              true
+            );
+            if (user.data[0].broadcaster_type == '')
+              offlineEmbed.addField('Rank:', 'BASE!', true);
+            else {
+              offlineEmbed.addField(
+                'Rank:',
+                user.data[0].broadcaster_type.toUpperCase() + '!',
+                true
+              );
+            }
+
+            // Offline Edit
+            try {
+              await announcedChannel.messages
+                .fetch({
+                  around: embedID,
+                  limit: 1
+                })
+                .then(msg => {
+                  const fetchedMsg = msg.first();
+                  fetchedMsg.edit(offlineEmbed);
+                });
+            } catch (error) {
+              ++failedAttempts;
+              if (failedAttempts == 5) {
+                message.reply(':x: Could not edit message');
+                console.log(error);
+                message.guild.twitchData.isRunning = false;
+                message.guild.twitchData.Interval = clearInterval(
+                  message.guild.twitchData.Interval
+                );
+              }
+              return;
+            }
+            // Change Embed Status
+            message.guild.twitchData.embedStatus = 'end';
+          }
+          // Reset Fail Counter
+          failedAttempts = 0;
         }, DBInfo.timer * 60000); //setInterval() is in MS and needs to be converted to minutes
       }
       message.channel.send(enabledEmbed);
@@ -159,229 +409,6 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       );
       message.channel.send(disabledEmbed);
       return;
-    }
-
-    async function announcer() {
-      const announcedChannel = message.guild.channels.cache.find(
-        channel => channel.id == DBInfo.channelID
-      );
-      try {
-        var streamInfo = await TwitchAPI.getStream(
-          TwitchAPI.access_token,
-          twitchClientID,
-          user.data[0].id
-        );
-      } catch (e) {
-        ++failedAttempts;
-        if (failedAttempts == 5) {
-          message.guild.twitchData.isRunning = false;
-          message.guild.twitchData.Interval = clearInterval(
-            message.guild.twitchData.Interval
-          );
-          message.reply(':x: Twitch Announcer has stopped!\n' + e);
-        }
-        return;
-      }
-
-      // Set Status to Offline
-      if (
-        !streamInfo.data[0] &&
-        message.guild.twitchData.embedStatus == 'sent'
-      ) {
-        message.guild.twitchData.embedStatus = 'offline';
-      }
-      // Set Status To Online
-      if (
-        message.guild.twitchData.embedStatus != 'sent' &&
-        streamInfo.data[0]
-      ) {
-        message.guild.twitchData.embedStatus = 'online';
-      }
-
-      // Online Status
-      if (message.guild.twitchData.embedStatus == 'online') {
-        currentGame = streamInfo.data[0].game_name;
-
-        try {
-          user = await TwitchAPI.getUserInfo(
-            TwitchAPI.access_token,
-            twitchClientID,
-            `${DBInfo.name}`
-          );
-        } catch (e) {
-          ++failedAttempts;
-          if (failedAttempts == 5) {
-            message.guild.twitchData.isRunning = false;
-            message.guild.twitchData.Interval = clearInterval(
-              message.guild.twitchData.Interval
-            );
-            message.reply(':x: Twitch Announcer has stopped!\n' + e);
-          }
-          return;
-        }
-
-        try {
-          var gameInfo = await TwitchAPI.getGames(
-            TwitchAPI.access_token,
-            twitchClientID,
-            streamInfo.data[0].game_id
-          );
-
-          var result = await probe(
-            gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
-          );
-          var canvas = Canvas.createCanvas(result.width, result.height);
-          var ctx = canvas.getContext('2d');
-          // Since the image takes time to load, you should await it
-          var background = await Canvas.loadImage(
-            gameInfo.data[0].box_art_url.replace(/-{width}x{height}/g, '')
-          );
-          // This uses the canvas dimensions to stretch the image onto the entire canvas
-          ctx.drawImage(background, 0, 0, canvas.width, canvas.height);
-          // Use helpful Attachment class structure to process the file for you
-          var attachment = new MessageAttachment(
-            canvas.toBuffer(),
-            'box_art.png'
-          );
-        } catch (e) {
-          ++failedAttempts;
-          if (failedAttempts == 5) {
-            message.guild.twitchData.isRunning = false;
-            message.guild.twitchData.Interval = clearInterval(
-              message.guild.twitchData.Interval
-            );
-            message.reply(':x: Twitch Announcer has stopped!\n' + e);
-          }
-          return;
-        }
-
-        // Online Embed
-        const onlineEmbed = new MessageEmbed()
-          .setAuthor(
-            `Twitch Announcement: ${user.data[0].display_name} Online!`,
-            user.data[0].profile_image_url,
-            'https://twitch.tv/' + user.data[0].display_name
-          )
-          .setURL('https://twitch.tv/' + user.data[0].display_name)
-          .setTitle(user.data[0].display_name + ' is playing ' + currentGame)
-          .addField('Stream Title:', streamInfo.data[0].title)
-          .addField('Currently Playing:', streamInfo.data[0].game_name, true)
-          .addField('Viewers:', streamInfo.data[0].viewer_count, true)
-          .setColor('#6441A4')
-          .setFooter(
-            'Stream Started',
-            'https://static.twitchcdn.net/assets/favicon-32-d6025c14e900565d6177.png' // Official icon link from Twitch.tv
-          )
-          .setImage(
-            streamInfo.data[0].thumbnail_url
-              .replace(/{width}x{height}/g, '1280x720')
-              .concat('?r=' + Math.floor(Math.random() * 10000 + 1)) // to ensure the image updates when refreshed
-          )
-          .setTimestamp(streamInfo.data[0].started_at)
-          .attachFiles(attachment)
-          .setThumbnail('attachment://box_art.png');
-
-        if (user.data[0].broadcaster_type == '')
-          onlineEmbed.addField('Rank:', 'BASE!', true);
-        else {
-          onlineEmbed.addField(
-            'Rank:',
-            user.data[0].broadcaster_type.toUpperCase() + '!',
-            true
-          );
-        }
-
-        // Online Send
-        try {
-          if (DBInfo.botSay.toLowerCase() != 'none') {
-            await announcedChannel.send(DBInfo.botSay),
-              await announcedChannel.send(onlineEmbed).then(result => {
-                embedID = result.id;
-              });
-          } else {
-            await announcedChannel.send(onlineEmbed).then(result => {
-              embedID = result.id;
-            });
-          }
-        } catch (error) {
-          ++failedAttempts;
-          if (failedAttempts == 5) {
-            message.reply(':x: Could not send message to channel');
-            console.log(error);
-            message.guild.twitchData.isRunning = false;
-            message.guild.twitchData.Interval = clearInterval(
-              message.guild.twitchData.Interval
-            );
-          }
-          return;
-        }
-        // Change Embed Status
-        message.guild.twitchData.embedStatus = 'sent';
-      }
-
-      // Offline Status
-      if (message.guild.twitchData.embedStatus == 'offline') {
-        const offlineEmbed = new MessageEmbed()
-          .setAuthor(
-            `Twitch Announcement: ${user.data[0].display_name} Offline`,
-            user.data[0].profile_image_url,
-            'https://twitch.tv/' + user.data[0].display_name
-          )
-          .setTitle(user.data[0].display_name + ' was playing ' + currentGame)
-          .setColor('#6441A4')
-          .setTimestamp()
-          .setFooter(
-            'Stream Ended',
-            'https://static.twitchcdn.net/assets/favicon-32-d6025c14e900565d6177.png'
-          )
-          .setThumbnail('attachment://box_art.png');
-
-        // Incase the there is no Profile Description
-        if (!user.data[0].description == '') {
-          offlineEmbed.addField(
-            'Profile Description:',
-            user.data[0].description
-          );
-        }
-        offlineEmbed.addField('View Counter:', user.data[0].view_count, true);
-        if (user.data[0].broadcaster_type == '')
-          offlineEmbed.addField('Rank:', 'BASE!', true);
-        else {
-          offlineEmbed.addField(
-            'Rank:',
-            user.data[0].broadcaster_type.toUpperCase() + '!',
-            true
-          );
-        }
-
-        // Offline Edit
-        try {
-          await announcedChannel.messages
-            .fetch({
-              around: embedID,
-              limit: 1
-            })
-            .then(msg => {
-              const fetchedMsg = msg.first();
-              fetchedMsg.edit(offlineEmbed);
-            });
-        } catch (error) {
-          ++failedAttempts;
-          if (failedAttempts == 5) {
-            message.reply(':x: Could not edit message');
-            console.log(error);
-            message.guild.twitchData.isRunning = false;
-            message.guild.twitchData.Interval = clearInterval(
-              message.guild.twitchData.Interval
-            );
-          }
-          return;
-        }
-        // Change Embed Status
-        message.guild.twitchData.embedStatus = 'end';
-      }
-      // Reset Fail Counter
-      failedAttempts = 0;
     }
   }
 };

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -165,7 +165,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         var streamInfo = await TwitchAPI.getStream(
           TwitchAPI.access_token,
           twitchClientID,
-          DBInfo.id
+          user.data[0].id
         );
       } catch (e) {
         message.guild.twitchData.Interval = clearInterval(

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -149,24 +149,6 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           );
 
           try {
-            user = await TwitchAPI.getUserInfo(
-              TwitchAPI.access_token,
-              twitchClientID,
-              `${DBInfo.name}`
-            );
-          } catch (e) {
-            ++failedAttempts;
-            if (failedAttempts == 5) {
-              message.guild.twitchData.isRunning = false;
-              message.guild.twitchData.Interval = clearInterval(
-                message.guild.twitchData.Interval
-              );
-              message.reply(':x: Twitch Announcer has stopped!\n' + e);
-            }
-            return;
-          }
-
-          try {
             var streamInfo = await TwitchAPI.getStream(
               TwitchAPI.access_token,
               twitchClientID,
@@ -328,6 +310,24 @@ module.exports = class TwitchAnnouncerCommand extends Command {
 
           // Offline Status
           if (message.guild.twitchData.embedStatus == 'offline') {
+            try {
+              user = await TwitchAPI.getUserInfo(
+                TwitchAPI.access_token,
+                twitchClientID,
+                `${DBInfo.name}`
+              );
+            } catch (e) {
+              ++failedAttempts;
+              if (failedAttempts == 5) {
+                message.guild.twitchData.isRunning = false;
+                message.guild.twitchData.Interval = clearInterval(
+                  message.guild.twitchData.Interval
+                );
+                message.reply(':x: Twitch Announcer has stopped!\n' + e);
+              }
+              return;
+            }
+
             const offlineEmbed = new MessageEmbed()
               .setAuthor(
                 `Twitch Announcement: ${user.data[0].display_name} Offline`,

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -140,10 +140,12 @@ module.exports = class TwitchAnnouncerCommand extends Command {
     let failedAttempts = 0;
     //Enable Twitch Announcer
     if (textFiltered == 'enable') {
-      message.guild.twitchData.isRunning = true;
-      message.guild.twitchData.Interval = setInterval(async function() {
-        await announcer();
-      }, DBInfo.timer * 60000); //setInterval() is in MS and needs to be converted to minutes
+      if (message.guild.twitchData.isRunning == false) {
+        message.guild.twitchData.isRunning = true;
+        message.guild.twitchData.Interval = setInterval(async function() {
+          await announcer();
+        }, DBInfo.timer * 60000); //setInterval() is in MS and needs to be converted to minutes
+      }
       message.channel.send(enabledEmbed);
       return;
     }

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -294,11 +294,13 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         try {
           if (DBInfo.botSay.toLowerCase() != 'none') {
             await announcedChannel.send(DBInfo.botSay),
-              await announcedChannel.send(onlineEmbed);
-            embedID = announcedChannel.lastMessage.id;
+              await announcedChannel.send(onlineEmbed).then(result => {
+                embedID = result.id;
+              });
           } else {
-            await announcedChannel.send(onlineEmbed);
-            embedID = announcedChannel.lastMessage.id;
+            await announcedChannel.send(onlineEmbed).then(result => {
+              embedID = result.id;
+            });
           }
         } catch (error) {
           ++failedAttempts;

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -137,6 +137,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       return;
     }
 
+    let failedAttempts = 0;
     //Enable Twitch Announcer
     if (textFiltered == 'enable') {
       message.guild.twitchData.isRunning = true;
@@ -168,11 +169,14 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           user.data[0].id
         );
       } catch (e) {
-        message.guild.twitchData.isRunning = false;
-        message.guild.twitchData.Interval = clearInterval(
-          message.guild.twitchData.Interval
-        );
-        message.reply(':x: Twitch Announcer has stopped!\n' + e);
+        ++failedAttempts;
+        if (failedAttempts == 5) {
+          message.guild.twitchData.isRunning = false;
+          message.guild.twitchData.Interval = clearInterval(
+            message.guild.twitchData.Interval
+          );
+          message.reply(':x: Twitch Announcer has stopped!\n' + e);
+        }
         return;
       }
 
@@ -202,11 +206,14 @@ module.exports = class TwitchAnnouncerCommand extends Command {
             `${DBInfo.name}`
           );
         } catch (e) {
-          message.guild.twitchData.isRunning = false;
-          message.guild.twitchData.Interval = clearInterval(
-            message.guild.twitchData.Interval
-          );
-          message.reply(':x: Twitch Announcer has stopped!\n' + e);
+          ++failedAttempts;
+          if (failedAttempts == 5) {
+            message.guild.twitchData.isRunning = false;
+            message.guild.twitchData.Interval = clearInterval(
+              message.guild.twitchData.Interval
+            );
+            message.reply(':x: Twitch Announcer has stopped!\n' + e);
+          }
           return;
         }
 
@@ -234,11 +241,14 @@ module.exports = class TwitchAnnouncerCommand extends Command {
             'box_art.png'
           );
         } catch (e) {
-          message.guild.twitchData.isRunning = false;
-          message.guild.twitchData.Interval = clearInterval(
-            message.guild.twitchData.Interval
-          );
-          message.reply(':x: Twitch Announcer has stopped!\n' + e);
+          ++failedAttempts;
+          if (failedAttempts == 5) {
+            message.guild.twitchData.isRunning = false;
+            message.guild.twitchData.Interval = clearInterval(
+              message.guild.twitchData.Interval
+            );
+            message.reply(':x: Twitch Announcer has stopped!\n' + e);
+          }
           return;
         }
 
@@ -289,12 +299,15 @@ module.exports = class TwitchAnnouncerCommand extends Command {
             embedID = announcedChannel.lastMessage.id;
           }
         } catch (error) {
-          message.reply(':x: Could not send message to channel');
-          console.log(error);
-          message.guild.twitchData.isRunning = false;
-          message.guild.twitchData.Interval = clearInterval(
-            message.guild.twitchData.Interval
-          );
+          ++failedAttempts;
+          if (failedAttempts == 5) {
+            message.reply(':x: Could not send message to channel');
+            console.log(error);
+            message.guild.twitchData.isRunning = false;
+            message.guild.twitchData.Interval = clearInterval(
+              message.guild.twitchData.Interval
+            );
+          }
           return;
         }
         message.guild.twitchData.embedStatus = 'sent';
@@ -345,15 +358,20 @@ module.exports = class TwitchAnnouncerCommand extends Command {
               fetchedMsg.edit(offlineEmbed);
             });
         } catch (error) {
-          message.reply(':x: Could not edit message');
-          console.log(error);
-          message.guild.twitchData.isRunning = false;
-          message.guild.twitchData.Interval = clearInterval(
-            message.guild.twitchData.Interval
-          );
+          ++failedAttempts;
+          if (failedAttempts == 5) {
+            message.reply(':x: Could not edit message');
+            console.log(error);
+            message.guild.twitchData.isRunning = false;
+            message.guild.twitchData.Interval = clearInterval(
+              message.guild.twitchData.Interval
+            );
+          }
           return;
         }
       }
+      // reset counter when it completes an interval
+      failedAttempts = 0;
     }
   }
 };

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -51,7 +51,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
     var embedID;
     let currentGame;
 
-    //Error Missing DB
+    // Error Missing DB
     if (DBInfo == undefined) {
       message.reply(
         ':no_entry: No settings were found, please run `' +
@@ -72,7 +72,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       return;
     }
 
-    //Enable Embed
+    // Enable Embed
     const enabledEmbed = new MessageEmbed()
       .setAuthor(
         message.member.guild.name + ' Announcer Settings',
@@ -100,7 +100,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         .setTimestamp(DBInfo.date);
     }
 
-    //Disable Embed
+    // Disable Embed
     const disabledEmbed = new MessageEmbed()
       .setAuthor(
         message.member.guild.name + ' Announcer Settings',
@@ -128,7 +128,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         .setTimestamp(DBInfo.date);
     }
 
-    //Check embed trigger
+    // Check Twitch Announcer Status
     if (textFiltered == 'check') {
       if (message.guild.twitchData.isRunning) {
         message.channel.send(enabledEmbed);
@@ -138,10 +138,10 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       return;
     }
 
-    let failedAttempts = 0;
-    //Enable Twitch Announcer
+    // Enable Twitch Announcer
     if (textFiltered == 'enable') {
       if (message.guild.twitchData.isRunning == false) {
+        var failedAttempts = 0;
         message.guild.twitchData.isRunning = true;
         message.guild.twitchData.Interval = setInterval(async function() {
           await announcer();
@@ -151,7 +151,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       return;
     }
 
-    //Disable Twitch Announcer
+    // Disable Twitch Announcer
     if (textFiltered == 'disable') {
       message.guild.twitchData.isRunning = false;
       message.guild.twitchData.Interval = clearInterval(
@@ -183,14 +183,14 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         return;
       }
 
-      //Offline Status Set
+      // Set Status to Offline
       if (
         !streamInfo.data[0] &&
         message.guild.twitchData.embedStatus == 'sent'
       ) {
         message.guild.twitchData.embedStatus = 'offline';
       }
-      //Online Status set
+      // Set Status To Online
       if (
         message.guild.twitchData.embedStatus != 'sent' &&
         streamInfo.data[0]
@@ -198,7 +198,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         message.guild.twitchData.embedStatus = 'online';
       }
 
-      //Online Trigger
+      // Online Status
       if (message.guild.twitchData.embedStatus == 'online') {
         currentGame = streamInfo.data[0].game_name;
 
@@ -255,7 +255,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           return;
         }
 
-        //Online Embed
+        // Online Embed
         const onlineEmbed = new MessageEmbed()
           .setAuthor(
             `Twitch Announcement: ${user.data[0].display_name} Online!`,
@@ -291,7 +291,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           );
         }
 
-        //Online Send
+        // Online Send
         try {
           if (DBInfo.botSay.toLowerCase() != 'none') {
             await announcedChannel.send(DBInfo.botSay),
@@ -315,12 +315,12 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           }
           return;
         }
+        // Change Embed Status
         message.guild.twitchData.embedStatus = 'sent';
       }
 
-      //Offline Trigger
+      // Offline Status
       if (message.guild.twitchData.embedStatus == 'offline') {
-        message.guild.twitchData.embedStatus = 'end';
         const offlineEmbed = new MessageEmbed()
           .setAuthor(
             `Twitch Announcement: ${user.data[0].display_name} Offline`,
@@ -337,10 +337,13 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           .setThumbnail('attachment://box_art.png');
 
         // Incase the there is no Profile Description
-        if (!user.data[0].description == '')
-          offlineEmbed
-            .addField('Profile Description:', user.data[0].description)
-            .addField('View Counter:', user.data[0].view_count, true);
+        if (!user.data[0].description == '') {
+          offlineEmbed.addField(
+            'Profile Description:',
+            user.data[0].description
+          );
+        }
+        offlineEmbed.addField('View Counter:', user.data[0].view_count, true);
         if (user.data[0].broadcaster_type == '')
           offlineEmbed.addField('Rank:', 'BASE!', true);
         else {
@@ -351,7 +354,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           );
         }
 
-        //Offline Edit
+        // Offline Edit
         try {
           await announcedChannel.messages
             .fetch({
@@ -374,8 +377,10 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           }
           return;
         }
+        // Change Embed Status
+        message.guild.twitchData.embedStatus = 'end';
       }
-      // reset counter when it completes an interval
+      // Reset Fail Counter
       failedAttempts = 0;
     }
   }

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -168,6 +168,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           user.data[0].id
         );
       } catch (e) {
+        message.guild.twitchData.isRunning = false;
         message.guild.twitchData.Interval = clearInterval(
           message.guild.twitchData.Interval
         );
@@ -201,6 +202,10 @@ module.exports = class TwitchAnnouncerCommand extends Command {
             `${DBInfo.name}`
           );
         } catch (e) {
+          message.guild.twitchData.isRunning = false;
+          message.guild.twitchData.Interval = clearInterval(
+            message.guild.twitchData.Interval
+          );
           message.reply(':x: Twitch Announcer has stopped!\n' + e);
           return;
         }
@@ -229,6 +234,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
             'box_art.png'
           );
         } catch (e) {
+          message.guild.twitchData.isRunning = false;
           message.guild.twitchData.Interval = clearInterval(
             message.guild.twitchData.Interval
           );
@@ -285,6 +291,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         } catch (error) {
           message.reply(':x: Could not send message to channel');
           console.log(error);
+          message.guild.twitchData.isRunning = false;
           message.guild.twitchData.Interval = clearInterval(
             message.guild.twitchData.Interval
           );
@@ -340,6 +347,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         } catch (error) {
           message.reply(':x: Could not edit message');
           console.log(error);
+          message.guild.twitchData.isRunning = false;
           message.guild.twitchData.Interval = clearInterval(
             message.guild.twitchData.Interval
           );

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -63,25 +63,11 @@ module.exports = class TwitchAnnouncerCommand extends Command {
     }
 
     //Get Twitch Ready for Response Embeds
-    const scope = 'user:read:email';
-    let access_token; // Token is only valid for 24 Hours (needed to repeat this in Ticker Sections)
     let streamInfo;
     let gameInfo;
     try {
-      access_token = await TwitchAPI.getToken(
-        twitchClientID,
-        twitchClientSecret,
-        scope
-      );
-    } catch (e) {
-      clearInterval(Ticker);
-      message.reply(':x: Twitch Announcer has stopped!\n' + e);
-      return;
-    }
-
-    try {
       var user = await TwitchAPI.getUserInfo(
-        access_token,
+        TwitchAPI.access_token,
         twitchClientID,
         `${DBInfo.name}`
       );
@@ -168,7 +154,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
       message.channel.send(enabledEmbed);
 
       //Ticker Section (Loop)
-      var Ticker = setInterval(async function() {
+      var Ticker = setInterval(async function(currentMsgStatus) {
         if (currentMsgStatus == 'disable') {
           clearInterval(Ticker);
           return;
@@ -178,20 +164,8 @@ module.exports = class TwitchAnnouncerCommand extends Command {
           channel => channel.id == DBInfo.channelID
         );
         try {
-          access_token = await TwitchAPI.getToken(
-            twitchClientID,
-            twitchClientSecret,
-            scope
-          );
-        } catch (e) {
-          clearInterval(Ticker);
-          message.reply(':x: Twitch Announcer has stopped!\n' + e);
-          return;
-        }
-
-        try {
           user = await TwitchAPI.getUserInfo(
-            access_token,
+            TwitchAPI.access_token,
             twitchClientID,
             `${DBInfo.name}`
           );
@@ -204,7 +178,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
         var user_id = user.data[0].id;
         try {
           streamInfo = await TwitchAPI.getStream(
-            access_token,
+            TwitchAPI.access_token,
             twitchClientID,
             user_id
           );
@@ -233,7 +207,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
 
           try {
             gameInfo = await TwitchAPI.getGames(
-              access_token,
+              TwitchAPI.access_token,
               twitchClientID,
               streamInfo.data[0].game_id
             );

--- a/commands/guild/twitch-announcer.js
+++ b/commands/guild/twitch-announcer.js
@@ -49,6 +49,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
 
     var textFiltered = textRaw.toLowerCase();
     var embedID;
+    let currentGame;
 
     //Error Missing DB
     if (DBInfo == undefined) {
@@ -199,7 +200,7 @@ module.exports = class TwitchAnnouncerCommand extends Command {
 
       //Online Trigger
       if (message.guild.twitchData.embedStatus == 'online') {
-        var currentGame = streamInfo.data[0].game_name;
+        currentGame = streamInfo.data[0].game_name;
 
         try {
           user = await TwitchAPI.getUserInfo(

--- a/commands/other/twitchstatus.js
+++ b/commands/other/twitchstatus.js
@@ -18,8 +18,8 @@ module.exports = class TwitchStatusCommand extends Command {
       description:
         'A quick check to see if a streamer is currently online. or to give a shout-out a fellow streamer',
       throttling: {
-        usages: 45, // 45 queries
-        duration: 60 // every 60 seconds
+        usages: 45,
+        duration: 60
       },
       args: [
         {
@@ -46,7 +46,6 @@ module.exports = class TwitchStatusCommand extends Command {
     }
 
     const user_id = user.data[0].id;
-
     try {
       var streamInfo = await TwitchAPI.getStream(
         TwitchAPI.access_token,
@@ -79,8 +78,8 @@ module.exports = class TwitchStatusCommand extends Command {
       if (!user.data[0].description == '')
         offlineEmbed
           .addField('Profile Description:', user.data[0].description)
-
           .addField('View Counter:', user.data[0].view_count, true);
+
       if (user.data[0].broadcaster_type == '')
         offlineEmbed.addField('Rank:', 'BASE!', true);
       else {

--- a/commands/other/twitchstatus.js
+++ b/commands/other/twitchstatus.js
@@ -33,24 +33,10 @@ module.exports = class TwitchStatusCommand extends Command {
 
   async run(message, { textRaw }) {
     // Twitch Section
-    const scope = 'user:read:email';
     const textFiltered = textRaw.replace(/https\:\/\/twitch.tv\//g, '');
-    let access_token;
-
-    try {
-      access_token = await TwitchAPI.getToken(
-        twitchClientID,
-        twitchClientSecret,
-        scope
-      );
-    } catch (e) {
-      message.reply(e);
-      return;
-    }
-
     try {
       var user = await TwitchAPI.getUserInfo(
-        access_token,
+        TwitchAPI.access_token,
         twitchClientID,
         textFiltered
       );
@@ -63,7 +49,7 @@ module.exports = class TwitchStatusCommand extends Command {
 
     try {
       var streamInfo = await TwitchAPI.getStream(
-        access_token,
+        TwitchAPI.access_token,
         twitchClientID,
         user_id
       );
@@ -111,7 +97,7 @@ module.exports = class TwitchStatusCommand extends Command {
     // Box Art Recreation
     try {
       var gameInfo = await TwitchAPI.getGames(
-        access_token,
+        TwitchAPI.access_token,
         twitchClientID,
         streamInfo.data[0].game_id
       );

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const db = require('quick.db');
 const Canvas = require('canvas');
 
 Structures.extend('Guild', function(Guild) {
-  class MusicGuild extends Guild {
+  class GuildData extends Guild {
     constructor(client, data) {
       super(client, data);
       this.musicData = {
@@ -41,7 +41,7 @@ Structures.extend('Guild', function(Guild) {
       this.musicData.songDispatcher = null;
     }
   }
-  return MusicGuild;
+  return GuildData;
 });
 
 const client = new CommandoClient({

--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ Structures.extend('Guild', function(Guild) {
         triviaQueue: [],
         triviaScore: new Map()
       };
+      this.twitchData = {
+        Interval: null,
+        embedStatus: null,
+        isRunning: false
+      };
     }
     resetMusicDataOnError() {
       this.musicData.queue.length = 0;
@@ -37,20 +42,6 @@ Structures.extend('Guild', function(Guild) {
     }
   }
   return MusicGuild;
-});
-
-Structures.extend('Guild', function(Guild) {
-  class TwitchGuild extends Guild {
-    constructor(client, data) {
-      super(client, data);
-      this.twitchData = {
-        Interval: null,
-        embedStatus: null,
-        isRunning: false
-      };
-    }
-  }
-  return TwitchGuild;
 });
 
 const client = new CommandoClient({

--- a/index.js
+++ b/index.js
@@ -38,6 +38,16 @@ Structures.extend('Guild', function(Guild) {
   return MusicGuild;
 });
 
+Structures.extend('Guild', function(Guild) {
+  class TwitchGuild extends Guild {
+    constructor(client, data) {
+      super(client, data);
+      this.twitchData = { Interval: null };
+    }
+  }
+  return TwitchGuild;
+});
+
 const client = new CommandoClient({
   commandPrefix: prefix,
   owner: discord_owner_id

--- a/index.js
+++ b/index.js
@@ -42,7 +42,11 @@ Structures.extend('Guild', function(Guild) {
   class TwitchGuild extends Guild {
     constructor(client, data) {
       super(client, data);
-      this.twitchData = { Interval: null };
+      this.twitchData = {
+        Interval: null,
+        embedStatus: null,
+        isRunning: false
+      };
     }
   }
   return TwitchGuild;

--- a/resources/twitch/twitch-api.js
+++ b/resources/twitch/twitch-api.js
@@ -121,9 +121,9 @@ module.exports = class TwitchAPI {
   }
 };
 
-// get first access_token
 const TwitchAPI = require('./twitch-api.js'); // having this at the Top gives a Circular Error Message
 const scope = 'user:read:email';
+// get first access_token
 (async function() {
   await TwitchAPI.getToken(twitchClientID, twitchClientSecret, scope)
     .then(result => {

--- a/resources/twitch/twitch-api.js
+++ b/resources/twitch/twitch-api.js
@@ -46,7 +46,7 @@ module.exports = class TwitchAPI {
         );
         const json = await response.json();
         if (json.status == `400`) {
-          reject(`:x: ${username} was Invaild, Please try again.`);
+          reject(`:x: ${username} was Invalid, Please try again.`);
           return;
         }
 
@@ -120,3 +120,29 @@ module.exports = class TwitchAPI {
     });
   }
 };
+
+// get first access_token
+const TwitchAPI = require('./twitch-api.js'); // having this at the Top gives a Circular Error Message
+const scope = 'user:read:email';
+(async function() {
+  await TwitchAPI.getToken(twitchClientID, twitchClientSecret, scope)
+    .then(result => {
+      module.exports.access_token = result;
+      return;
+    })
+    .catch(e => {
+      console.log(e);
+      return;
+    });
+})();
+// 24 Hour access_token refresh
+setInterval(async function() {
+  await TwitchAPI.getToken(twitchClientID, twitchClientSecret, scope)
+    .then(result => {
+      module.exports.access_token = result;
+    })
+    .catch(e => {
+      console.log(e);
+      return;
+    });
+}, 86400000);

--- a/resources/twitch/twitch-api.js
+++ b/resources/twitch/twitch-api.js
@@ -51,19 +51,19 @@ module.exports = class TwitchAPI {
         }
 
         if (json.status == `429`) {
-          reject(`:x: Rate Limit exceeded. Please try again in a few minutes.`);
+          reject(`Rate Limit exceeded. Please try again in a few minutes.`);
           return;
         }
 
         if (json.status == `503`) {
           reject(
-            `:x: Twitch service's are currently unavailable. Please try again later.`
+            `Twitch service's are currently unavailable. Please try again later.`
           );
           return;
         }
 
         if (json.data[0] == null) {
-          reject(`:x: Streamer ${username} was not found, Please try again.`);
+          reject(`Streamer ${username} was not found, Please try again.`);
           return;
         }
         resolve(json);


### PR DESCRIPTION
Addressing #544

- [x]  use less token calls, removing the constant refresh of the access token and have it refresh every 24 hours instead
- [x]  Fix bug with `!ta disable` (somehow now the timer can't be stopped with !ta disable command)
- [x]  allow 5 failed attempts before disabling the timer
- [x] Pass 7 days without errors (make sure the original issue is resolved)

EDIT: "I would like the Timers to persist even if the bot restarts/reboot(if possible)" <-- I couldn't think of a way to do that, I'm open to ideas <3 (stuck on how to ***quietly***  restart the twitch announcer for the guild on start up for those whom are set up and enabled, without using the `!ta enable` command)

EDIT: I goofed 50a6562 doesn't quite fulfill no.2 on the list (if server 1 enables, and then server 2 disables, now both servers are disabled)
7f83f50 does fix the `!ta disable` bug

Much Love
-Bacon