### PR TITLE
Update Welcome message - Parse {serverName} & {memberName}

### DIFF
--- a/commands/guild/welcome-message-settings.js
+++ b/commands/guild/welcome-message-settings.js
@@ -21,7 +21,8 @@ module.exports = class WelcomeSettingsCommand extends Command {
         '```' + `${prefix}welcomesettings - to restore Defaults`,
         `${prefix}welcomesettings "Channel-name" "My Title" "Upper Text" "MainText" "My Wallpaper URL" 700 250`,
         `${prefix}welcomesettings "" "My Title" "Upper Text" "" "" 800 400`,
-        `${prefix}welcomesettings "s" "s" "s" "Upper Text" "My Wallpaper URL" "700" "250" - to only change the Main Text and Wallpaper settings` +
+        `${prefix}welcomesettings "s" "s" "s" "Main Text" "My Wallpaper URL" "700" "250" - to only change the Main Text and Wallpaper settings`,
+        `${prefix}welcomesettings "s" "s" "Welcome to {serverName}" "{memberName}" "My Wallpaper URL" "700" "250" - You can use "{serverName}" to parse the server name and "{memberName}" to parse Members Name to the Image` +
           '```'
       ],
       description:

--- a/index.js
+++ b/index.js
@@ -132,69 +132,47 @@ client.on('guildMemberAdd', async member => {
     ctx.strokeStyle = '#000000';
     ctx.strokeRect(0, 0, canvas.width, canvas.height);
 
-    // Upper Text Options Default
-    if (welcomeMsgSettings.topImageText == 'default') {
-      ctx.font = '26px Open Sans Light'; // This needs to match the family Name on line 65
-      ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
-      ctx.fillText(
-        `Welcome to ${member.guild.name}`, //<-- didn't play nice being stored in DB -Default
-        canvas.width / 2.5,
-        canvas.height / 3.5
-      );
-      ctx.strokeStyle = `#FFFFFF`; // Secondary Color of Text on the top of welcome for depth/shadow the stroke is under the main color
-      ctx.strokeText(
-        `Welcome to ${member.guild.name}`, //<-- didn't play nice being stored in DB -Default
-        canvas.width / 2.5,
-        canvas.height / 3.5
-      );
-    } else {
-      // Upper Text Options DB
-      ctx.font = '26px Open Sans Light'; // if the font register changed this needs to match the family Name on line 65
-      ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
-      ctx.fillText(
-        welcomeMsgSettings.topImageText,
-        canvas.width / 2.5,
-        canvas.height / 3.5
-      );
-      ctx.strokeStyle = `#FFFFFF`; // Secondary Color of Text on the top of welcome for depth/shadow the stroke is under the main color
-      ctx.strokeText(
-        welcomeMsgSettings.topImageText,
-        canvas.width / 2.5,
-        canvas.height / 3.5
-      );
-    }
+    // Upper Text Options
+    ctx.font = '26px Open Sans Light'; // if the font register changed this needs to match the family Name on line 65
+    ctx.fillStyle = '#FFFFFF'; // Main Color of the Text on the top of the welcome image
+    ctx.fillText(
+      welcomeMsgSettings.topImageText
+        .replace(/\{serverName\}/gi, member.guild.name)
+        .replace(/\{memberName\}/gi, member.displayName)
+        .replace('default', `Welcome to ${member.guild.name}`),
+      canvas.width / 2.5,
+      canvas.height / 3.5
+    );
+    ctx.strokeStyle = `#FFFFFF`; // Secondary Color of Text on the top of welcome for depth/shadow the stroke is under the main color
+    ctx.strokeText(
+      welcomeMsgSettings.topImageText
+        .replace(/\{serverName\}/gi, member.guild.name)
+        .replace(/\{memberName\}/gi, member.displayName)
+        .replace('default', `Welcome to ${member.guild.name}`),
+      canvas.width / 2.5,
+      canvas.height / 3.5
+    );
 
-    // Lower Text Options Defaults
-    if (welcomeMsgSettings.bottomImageText == 'default') {
-      ctx.font = applyText(canvas, `${member.displayName}!`);
-      ctx.fillStyle = '#FFFFFF'; // Main Color for the members name for the welcome image
-      ctx.fillText(
-        `${member.displayName}!`, //<-- didn't play nice being stored in DB -Default
-        canvas.width / 2.5,
-        canvas.height / 1.8
-      );
-      ctx.strokeStyle = `#FF0000`; // Secondary Color for the member name to add depth/shadow to the text
-      ctx.strokeText(
-        `${member.displayName}!`, //<-- didn't play nice being stored in DB -Default
-        canvas.width / 2.5,
-        canvas.height / 1.8
-      );
-    } else {
-      //Lower Text Options DB
-      ctx.font = applyText(canvas, `${member.displayName}!`);
-      ctx.fillStyle = '#FFFFFF'; // Main Color for the members name for the welcome image
-      ctx.fillText(
-        welcomeMsgSettings.bottomImageText,
-        canvas.width / 2.5,
-        canvas.height / 1.8
-      );
-      ctx.strokeStyle = `#FF0000`; // Secondary Color for the member name to add depth/shadow to the text
-      ctx.strokeText(
-        welcomeMsgSettings.bottomImageText,
-        canvas.width / 2.5,
-        canvas.height / 1.8
-      );
-    }
+    //Lower Text Options
+    ctx.font = applyText(canvas, `${member.displayName}!`);
+    ctx.fillStyle = '#FFFFFF'; // Main Color for the members name for the welcome image
+    ctx.fillText(
+      welcomeMsgSettings.bottomImageText
+        .replace(/\{serverName\}/gi, member.guild.name)
+        .replace(/\{memberName\}/gi, member.displayName)
+        .replace('default', `${member.displayName}!`),
+      canvas.width / 2.5,
+      canvas.height / 1.8
+    );
+    ctx.strokeStyle = `#FF0000`; // Secondary Color for the member name to add depth/shadow to the text
+    ctx.strokeText(
+      welcomeMsgSettings.bottomImageText
+        .replace(/\{serverName\}/gi, member.guild.name)
+        .replace(/\{memberName\}/gi, member.displayName)
+        .replace('default', `${member.displayName}!`),
+      canvas.width / 2.5,
+      canvas.height / 1.8
+    );
 
     // Avatar Shape Options
     ctx.beginPath();
@@ -220,12 +198,16 @@ client.on('guildMemberAdd', async member => {
       .attachFiles(attachment)
       .setImage('attachment://welcome-image.png')
       .setFooter(`Type help for a feature list!`)
-      .setTimestamp();
-    if (welcomeMsgSettings.embedTitle == 'default') {
-      embed.setTitle(
-        `:speech_balloon: Hey ${member.displayName}, You look new to ${member.guild.name}!` //<-- didn't play nice being stored in DB -Default
+      .setTimestamp()
+      .setTitle(
+        welcomeMsgSettings.embedTitle
+          .replace(/\{serverName\}/gi, member.guild.name)
+          .replace(/\{memberName\}/gi, member.displayName)
+          .replace(
+            'default',
+            `:speech_balloon: Hey ${member.displayName}, You look new to ${member.guild.name}!`
+          )
       );
-    } else embed.setTitle(welcomeMsgSettings.embedTitle);
 
     // Sends a DM if set to or if destination is not present in DB(pre channel option users)
     if (


### PR DESCRIPTION
Ready for review (no rush)

Allows user to use {serverName} & {memberName} in the welcome settings for more customizations
was a request from a discord server that uses the bot I operate,
they noticed that you could not get the welcome image to display the new members name,
the only option was to have the 'lowerText' option set to 'default'

and a reduction in bulk in the `index.js` (removal of multiple 'if' 'else' statements that were used for the 'default' option)
it is backwards compatible so no special instruction to update :D


Much Love
-Bacon