### PR TITLE
Change npm command to ci on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ librsvg-dev
 
 WORKDIR "/Master-Bot"
 COPY package.json package-lock.json ./
-RUN npm i --production
+RUN npm ci --production
 
 COPY ./ ./
 CMD ["npm", "start"]


### PR DESCRIPTION
Like it says in the [documentation](https://docs.npmjs.com/cli/v7/commands/npm-ci), `npm install` should be replaced by `npm ci` on deployment to force a proper clean install of the dependencies according to the `package-lock.json` file.