### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/utils/trivia/utilFunctions.ts
+++ b/src/lib/utils/trivia/utilFunctions.ts
@@ -32,7 +32,7 @@ export function normalizeValue(value: string) {
 }
 export function capitalizeWords(str: string) {
   return str.replace(/\w\S*/g, function (txt) {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
   });
 }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.