### PR TITLE
Music Controls Update - Slash Commands Control Embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "genius-discord-lyrics": "1.0.5",
         "iso-639-1": "^2.1.12",
         "lavaclient": "4.0.8-rc.2",
+        "metadata-filter": "^1.3.0",
         "string-progressbar": "^1.0.4",
         "tiny-typed-emitter": "^2.1.0"
       },
@@ -1927,6 +1928,14 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/metadata-filter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/metadata-filter/-/metadata-filter-1.3.0.tgz",
+      "integrity": "sha512-fl1I+w6KA+pO0RoRdzABxmgwwvruoHCYTV9hU793hFS/WJmGIRHYOz1s62mQ8zKAaPbywiXnmmL1fW/bqPObxw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -4045,6 +4054,11 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "metadata-filter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/metadata-filter/-/metadata-filter-1.3.0.tgz",
+      "integrity": "sha512-fl1I+w6KA+pO0RoRdzABxmgwwvruoHCYTV9hU793hFS/WJmGIRHYOz1s62mQ8zKAaPbywiXnmmL1fW/bqPObxw=="
     },
     "micromatch": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "genius-discord-lyrics": "1.0.5",
     "iso-639-1": "^2.1.12",
     "lavaclient": "4.0.8-rc.2",
+    "metadata-filter": "^1.3.0",
     "string-progressbar": "^1.0.4",
     "tiny-typed-emitter": "^2.1.0"
   },

--- a/src/commands/music/create-playlist.ts
+++ b/src/commands/music/create-playlist.ts
@@ -29,7 +29,7 @@ export class CreatePlaylistCommand extends Command {
       });
     } catch (error) {
       await interaction.reply({
-        content: `You already have a playlist named **${playlistName}**`
+        content: `:x: You already have a playlist named **${playlistName}**`
       });
       return;
     }

--- a/src/commands/music/delete-playlist.ts
+++ b/src/commands/music/delete-playlist.ts
@@ -29,7 +29,7 @@ export class DeletePlaylistCommand extends Command {
       });
     } catch (error) {
       console.error(error);
-      return interaction.reply(
+      return await interaction.reply(
         ':x: Something went wrong! Please try again later'
       );
     }

--- a/src/commands/music/delete-playlist.ts
+++ b/src/commands/music/delete-playlist.ts
@@ -29,11 +29,15 @@ export class DeletePlaylistCommand extends Command {
       });
     } catch (error) {
       console.error(error);
-      return interaction.reply('Something went wrong! Please try again later');
+      return interaction.reply(
+        ':x: Something went wrong! Please try again later'
+      );
     }
 
     if (deleted) {
-      return await interaction.reply(`Deleted **${playlistName}**`);
+      return await interaction.reply(
+        `:wastebasket: Deleted **${playlistName}**`
+      );
     }
   }
 

--- a/src/commands/music/display-playlist.ts
+++ b/src/commands/music/display-playlist.ts
@@ -31,7 +31,7 @@ export class DisplayPlaylistCommand extends Command {
 
     if (!playlist) {
       return await interaction.reply(
-        'Something went wrong! Please try again soon'
+        ':x: Something went wrong! Please try again soon'
       );
     }
 

--- a/src/commands/music/leave.ts
+++ b/src/commands/music/leave.ts
@@ -24,10 +24,9 @@ export class LeaveCommand extends Command {
     const { client } = container;
 
     const player = client.music.players.get(interaction.guild!.id);
+    await handlePlayerEmbed(player?.queue!);
     player?.disconnect();
     client.music.destroyPlayer(player!.guildId);
-
-    await handlePlayerEmbed(player?.queue!);
     clearTimeout(client.leaveTimers[player?.guildId!]);
     return await interaction.reply('Leaving voice channel');
   }

--- a/src/commands/music/leave.ts
+++ b/src/commands/music/leave.ts
@@ -21,7 +21,19 @@ import { container } from '@sapphire/framework';
 export class LeaveCommand extends Command {
   public override async chatInputRun(interaction: CommandInteraction) {
     const { client } = container;
-
+    await interaction
+      .channel!.fetch()
+      .then(
+        async channel =>
+          await channel.messages.fetch(
+            client.playerEmbeds[interaction.guild!.id]
+          )
+      )
+      .then(async oldMessage => {
+        await oldMessage
+          .delete()
+          .catch(error => console.log('Failed to Delete Old Message.', error));
+      });
     const player = client.music.players.get(interaction.guild!.id);
     player?.disconnect();
     client.music.destroyPlayer(player!.guildId);

--- a/src/commands/music/leave.ts
+++ b/src/commands/music/leave.ts
@@ -6,7 +6,7 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
-import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
+import { deletePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'leave',
@@ -24,7 +24,7 @@ export class LeaveCommand extends Command {
     const { client } = container;
 
     const player = client.music.players.get(interaction.guild!.id);
-    await handlePlayerEmbed(player?.queue!);
+    await deletePlayerEmbed(player?.queue!);
     player?.disconnect();
     client.music.destroyPlayer(player!.guildId);
     clearTimeout(client.leaveTimers[player?.guildId!]);

--- a/src/commands/music/loop.ts
+++ b/src/commands/music/loop.ts
@@ -31,7 +31,7 @@ export class LoopCommand extends Command {
       case LoopType.None: // None (loop not enabled)
         if (option == 'queue') {
           if (!player?.queue.tracks.length) {
-            await interaction.reply('There are no tracks in queue!');
+            await interaction.reply(':x: There are no tracks in queue!');
             break;
           }
           player.queue.setLoop(LoopType.Queue);

--- a/src/commands/music/lyrics.ts
+++ b/src/commands/music/lyrics.ts
@@ -43,7 +43,11 @@ export class LyricsCommand extends Command {
         template: new MessageEmbed()
           .setColor('#ff0000')
           .setTitle(title)
-          .setFooter({ text: 'Provided by genius.com' })
+          .setFooter({
+            text: 'Provided by genius.com',
+            iconURL:
+              'https://assets.genius.com/images/apple-touch-icon.png?1652977688' // Genius Lyrics Icon
+          })
       });
 
       for (let i = 1; i <= lyricsIndex; ++i) {
@@ -56,7 +60,6 @@ export class LyricsCommand extends Command {
       }
 
       await interaction.followUp('Lyrics generated');
-      // @ts-ignore
       return paginatedLyrics.run(interaction);
     } catch (e) {
       console.log(e);

--- a/src/commands/music/move.ts
+++ b/src/commands/music/move.ts
@@ -67,7 +67,7 @@ export class MoveCommand extends Command {
         {
           name: 'new-position',
           description: 'What is the position you want to move the song to?',
-          type: 'STRING',
+          type: 'INTEGER',
           required: true
         }
       ]

--- a/src/commands/music/move.ts
+++ b/src/commands/music/move.ts
@@ -30,7 +30,7 @@ export class MoveCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (!player?.queue.tracks.length) {
-      return await interaction.reply('There are no tracks in queue!');
+      return await interaction.reply(':x: There are no tracks in queue!');
     }
 
     if (
@@ -40,7 +40,7 @@ export class MoveCommand extends Command {
       newPosition > player.queue.tracks.length ||
       currentPosition == newPosition
     ) {
-      return interaction.reply('Please enter valid position numbers!');
+      return interaction.reply(':x: Please enter valid position numbers!');
     }
 
     const title = player.queue.tracks[currentPosition - 1].title;

--- a/src/commands/music/music-trivia.ts
+++ b/src/commands/music/music-trivia.ts
@@ -14,6 +14,7 @@ import { container } from '@sapphire/framework';
 import fs from 'fs';
 import { getRandom } from '../../lib/utils/trivia/utilFunctions';
 import type { MessageChannel } from '../..';
+import prisma from '../../lib/prisma';
 
 @ApplyOptions<CommandOptions>({
   name: 'music-trivia',
@@ -47,8 +48,19 @@ export class MusicTriviaCommand extends Command {
     await player.connect(voiceChannel.id, { deafened: true });
 
     player.triviaQueue.add(tracks);
-    await player.setVolume(50); // todo from db
-
+    const channelDB = await prisma.guild.findFirst({
+      where: {
+        id: interaction.guild!.id
+      },
+      select: {
+        volume: true
+      }
+    });
+    if (channelDB?.volume) {
+      await player.setVolume(channelDB.volume);
+    } else {
+      await player.setVolume(50);
+    }
     const member = interaction.member as GuildMember;
     const membersInChannel = member!.voice!.channel!.members;
     membersInChannel.each((member: GuildMember) => {

--- a/src/commands/music/music-trivia.ts
+++ b/src/commands/music/music-trivia.ts
@@ -45,7 +45,7 @@ export class MusicTriviaCommand extends Command {
       interaction.user.id
     )?.channel as VoiceChannel;
 
-    await player.connect(voiceChannel.id, { deafened: true });
+    player.connect(voiceChannel.id, { deafened: true });
 
     player.triviaQueue.add(tracks);
     const channelDB = await prisma.guild.findFirst({

--- a/src/commands/music/my-playlists.ts
+++ b/src/commands/music/my-playlists.ts
@@ -35,7 +35,7 @@ export class MyPlaylistsCommand extends Command {
     });
 
     if (!playlists.length) {
-      return await interaction.reply('You have no custom playlists');
+      return await interaction.reply(':x: You have no custom playlists');
     }
 
     new PaginatedFieldMessageEmbed()

--- a/src/commands/music/now-playing.ts
+++ b/src/commands/music/now-playing.ts
@@ -8,10 +8,7 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import { NowPlayingEmbed } from '../../lib/utils/music/NowPlayingEmbed';
 import type { Song } from '../../lib/utils/queue/Song';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'now-playing',
@@ -39,7 +36,6 @@ export class NowPlayingCommand extends Command {
       player?.queue.last!,
       player?.paused
     );
-    await handlePlayerEmbed(player?.queue!);
     return interaction
       .reply({
         content: 'Getting Player Data...',

--- a/src/commands/music/now-playing.ts
+++ b/src/commands/music/now-playing.ts
@@ -36,6 +36,19 @@ export class NowPlayingCommand extends Command {
       player?.queue.last!,
       player?.paused
     );
+    await interaction
+      .channel!.fetch()
+      .then(
+        async channel =>
+          await channel.messages.fetch(
+            client.playerEmbeds[interaction.guild!.id]
+          )
+      )
+      .then(async oldMessage => {
+        await oldMessage
+          .delete()
+          .catch(error => console.log('Failed to Delete Old Message.', error));
+      });
     return interaction
       .reply({
         content: 'Getting Player Data...',

--- a/src/commands/music/now-playing.ts
+++ b/src/commands/music/now-playing.ts
@@ -8,7 +8,10 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import { NowPlayingEmbed } from '../../lib/utils/music/NowPlayingEmbed';
 import type { Song } from '../../lib/utils/queue/Song';
-import { embedButtons } from '../../lib/utils/music/ButtonHandler';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'now-playing',
@@ -36,19 +39,7 @@ export class NowPlayingCommand extends Command {
       player?.queue.last!,
       player?.paused
     );
-    await interaction
-      .channel!.fetch()
-      .then(
-        async channel =>
-          await channel.messages.fetch(
-            client.playerEmbeds[interaction.guild!.id]
-          )
-      )
-      .then(async oldMessage => {
-        await oldMessage
-          .delete()
-          .catch(error => console.log('Failed to Delete Old Message.', error));
-      });
+    await handlePlayerEmbed(player?.queue!);
     return interaction
       .reply({
         content: 'Getting Player Data...',

--- a/src/commands/music/pause.ts
+++ b/src/commands/music/pause.ts
@@ -29,6 +29,13 @@ export class PauseCommand extends Command {
     }
 
     player?.pause();
+    const maxLimit = 1.8e6; // 30 minutes
+    client.leaveTimers[player?.guildId!] = setTimeout(() => {
+      player?.queue.channel!.send(':zzz: Leaving due to inactivity');
+      player?.disconnect();
+      player?.node.destroyPlayer(player.guildId);
+    }, maxLimit);
+
     return await interaction.reply('Track paused');
   }
 

--- a/src/commands/music/pause.ts
+++ b/src/commands/music/pause.ts
@@ -1,3 +1,4 @@
+import { NowPlayingEmbed } from './../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
@@ -6,6 +7,10 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'pause',
@@ -28,13 +33,29 @@ export class PauseCommand extends Command {
       return await interaction.reply('The track is already on pause!');
     }
 
-    player?.pause();
+    await player?.pause();
     const maxLimit = 1.8e6; // 30 minutes
     client.leaveTimers[player?.guildId!] = setTimeout(() => {
       player?.queue.channel!.send(':zzz: Leaving due to inactivity');
       player?.disconnect();
       player?.node.destroyPlayer(player.guildId);
     }, maxLimit);
+    await handlePlayerEmbed(player?.queue!);
+    const NowPlaying = new NowPlayingEmbed(
+      player?.queue.current!,
+      player?.accuratePosition,
+      player?.queue.current?.length as number,
+      player?.volume!,
+      player?.queue.tracks!,
+      player?.queue.last!,
+      player?.paused
+    );
+
+    await embedButtons(
+      NowPlaying.NowPlayingEmbed(),
+      player?.queue!,
+      player?.queue.current!
+    );
 
     return await interaction.reply('Track paused');
   }

--- a/src/commands/music/pause.ts
+++ b/src/commands/music/pause.ts
@@ -30,7 +30,7 @@ export class PauseCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (player!.paused) {
-      return await interaction.reply('The track is already on pause!');
+      return await interaction.reply(':x: The track is already on pause!');
     }
 
     await player?.pause();
@@ -40,7 +40,9 @@ export class PauseCommand extends Command {
       player?.disconnect();
       player?.node.destroyPlayer(player.guildId);
     }, maxLimit);
+
     await handlePlayerEmbed(player?.queue!);
+
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,
       player?.accuratePosition,

--- a/src/commands/music/pause.ts
+++ b/src/commands/music/pause.ts
@@ -7,10 +7,7 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'pause',
@@ -40,8 +37,6 @@ export class PauseCommand extends Command {
       player?.disconnect();
       player?.node.destroyPlayer(player.guildId);
     }, maxLimit);
-
-    await handlePlayerEmbed(player?.queue!);
 
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -99,6 +99,7 @@ export class PlayCommand extends Command {
     tracks.forEach(value => {
       //@ts-ignore
       const trackInfo = value['info'] as TrackInfo;
+
       if (
         tracks.length >= optionsFile.maxQueueLength ||
         playerQueue + tracks.length >= optionsFile.maxQueueLength
@@ -133,7 +134,7 @@ export class PlayCommand extends Command {
     if (longerThan1Hour)
       await interaction.followUp(':x: Tracks longer than 1 hour were removed');
     // No more songs after option were applied
-    if (tracks.length == 0) return console.log('this is bad news bears');
+    if (tracks.length == 0) return;
 
     if (shufflePlaylist == 'Yes') shuffleQueue(tracks as Song[]);
 

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -1,10 +1,11 @@
+import type { TrackInfo } from '@lavaclient/types';
+import type { Song } from './../../lib/utils/queue/Song';
 import { NowPlayingEmbed } from '../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
   Command,
-  CommandOptions,
-  RegisterBehavior
+  CommandOptions
 } from '@sapphire/framework';
 import type { CommandInteraction, GuildMember } from 'discord.js';
 import { container } from '@sapphire/framework';
@@ -12,10 +13,9 @@ import type { MessageChannel } from '../..';
 import searchSong from '../../lib/utils/music/searchSong';
 import type { Addable } from '../../lib/utils/queue/Queue';
 import prisma from '../../lib/prisma';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
+import * as optionsFile from '../../options.json';
+import { shuffleQueue } from '../../lib/utils/music/handleOptions';
 
 @ApplyOptions<CommandOptions>({
   name: 'play',
@@ -31,12 +31,20 @@ import {
 export class PlayCommand extends Command {
   public override async chatInputRun(interaction: CommandInteraction) {
     await interaction.deferReply();
+
     const { client } = container;
     const query = interaction.options.getString('query', true);
     const isCustomPlaylist =
       interaction.options.getString('is-custom-playlist');
+    const shufflePlaylist = interaction.options.getString('shuffle-playlist');
 
     const interactionMember = interaction.member as GuildMember;
+
+    let player = client.music.players.get(interaction.guild!.id);
+    if (player?.queue.tracks.length! >= optionsFile.maxQueueLength)
+      return await interaction.followUp(
+        `:x: Can't add anymore songs to the queue`
+      );
 
     // had a precondition make sure the user is infact in a voice channel
     const voiceChannel = interaction.guild?.voiceStates?.cache?.get(
@@ -83,8 +91,52 @@ export class PlayCommand extends Command {
       tracks.push(...trackTuple[1]);
     }
 
-    let player = client.music.players.get(interaction.guild!.id);
-    await handlePlayerEmbed(player?.queue!);
+    // Apply options
+    let playerQueue: number = player?.queue.tracks.length ?? 0;
+    let liveStreams: boolean = false;
+    let queueLimit: boolean = false;
+    let longerThan1Hour: boolean = false;
+    tracks.forEach(value => {
+      //@ts-ignore
+      const trackInfo = value['info'] as TrackInfo;
+      if (
+        tracks.length >= optionsFile.maxQueueLength ||
+        playerQueue + tracks.length >= optionsFile.maxQueueLength
+      ) {
+        if (playerQueue > optionsFile.maxQueueLength) {
+          tracks.pop();
+          queueLimit = true;
+        }
+        playerQueue++;
+      }
+      if (optionsFile.playLiveStreams == false) {
+        if (trackInfo.isStream) {
+          tracks.pop();
+          liveStreams = true;
+        }
+      }
+      if (optionsFile.playVideosLongerThan1Hour == false) {
+        if (trackInfo.length > 3600) {
+          longerThan1Hour = true;
+          tracks.pop();
+        }
+      }
+    });
+    // inform user about changes to the expected queue
+    if (liveStreams)
+      await interaction.followUp(
+        ':x: Live Streams have been disabled, and were removed'
+      );
+    if (queueLimit)
+      message = `:x: Queue Limit reached, Could only add ${tracks.length} songs to the queue`;
+
+    if (longerThan1Hour)
+      await interaction.followUp(':x: Tracks longer than 1 hour were removed');
+    // No more songs after option were applied
+    if (tracks.length == 0) return console.log('this is bad news bears');
+
+    if (shufflePlaylist == 'Yes') shuffleQueue(tracks as Song[]);
+
     if (!player?.connected) {
       const channelDB = await prisma.guild.findFirst({
         where: {
@@ -98,7 +150,7 @@ export class PlayCommand extends Command {
       player ??= client.music.createPlayer(interaction.guild!.id);
       player.queue.channel = interaction.channel as MessageChannel;
       if (channelDB?.volume) {
-        player.setVolume(channelDB.volume);
+        await player.setVolume(channelDB.volume);
       }
       await player.connect(voiceChannel!.id, { deafened: true });
     }
@@ -138,38 +190,47 @@ export class PlayCommand extends Command {
   public override registerApplicationCommands(
     registery: ApplicationCommandRegistry
   ): void {
-    registery.registerChatInputCommand(
-      {
-        name: this.name,
-        description: this.description,
-        options: [
-          {
-            name: 'query',
-            description: 'What song or playlist would you like to listen to?',
-            type: 'STRING',
-            required: true
-          },
-          {
-            name: 'is-custom-playlist',
-            description: 'Is it a custom playlist?',
-            type: 'STRING',
-            choices: [
-              {
-                name: 'Yes',
-                value: 'Yes'
-              },
-              {
-                name: 'No',
-                value: 'No'
-              }
-            ]
-          }
-        ]
-      },
-      {
-        registerCommandIfMissing: false,
-        behaviorWhenNotIdentical: RegisterBehavior.Overwrite
-      }
-    );
+    registery.registerChatInputCommand({
+      name: this.name,
+      description: this.description,
+      options: [
+        {
+          name: 'query',
+          description: 'What song or playlist would you like to listen to?',
+          type: 'STRING',
+          required: true
+        },
+        {
+          name: 'is-custom-playlist',
+          description: 'Is it a custom playlist?',
+          type: 'STRING',
+          choices: [
+            {
+              name: 'Yes',
+              value: 'Yes'
+            },
+            {
+              name: 'No',
+              value: 'No'
+            }
+          ]
+        },
+        {
+          name: 'shuffle-playlist',
+          description: 'Would you like to shuffle the playlist?',
+          type: 'STRING',
+          choices: [
+            {
+              name: 'Yes',
+              value: 'Yes'
+            },
+            {
+              name: 'No',
+              value: 'No'
+            }
+          ]
+        }
+      ]
+    });
   }
 }

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -48,15 +48,12 @@ export class QueueCommand extends Command {
         iconURL: user.displayAvatarURL()
       });
 
-    await interaction.reply('Queue generated');
-
     new PaginatedFieldMessageEmbed()
       .setTitleField('Queue items')
-
       .setTemplate(baseEmbed)
       .setItems(queueItems)
-      .formatItems((item: any) => `${item.title}\n${item.value}`)
-      .setItemsPerPage(5)
+      .formatItems((item: any) => `**${item.title}**: ${item.value}`)
+      .setItemsPerPage(10)
       .make()
       .run(interaction);
   }

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -27,7 +27,7 @@ export class QueueCommand extends Command {
 
     const queueLength = player!.queue.tracks.length;
     if (!queueLength) {
-      return await interaction.reply('There are no songs in the queue!');
+      return await interaction.reply(':x: There are no songs in the queue!');
     }
 
     const queueItems = [];

--- a/src/commands/music/remove-from-playlist.ts
+++ b/src/commands/music/remove-from-playlist.ts
@@ -32,17 +32,17 @@ export class RemoveFromPlaylistCommand extends Command {
         }
       });
     } catch (error) {
-      return await interaction.followUp('Something went wrong!');
+      return await interaction.followUp(':x: Something went wrong!');
     }
 
     const songs = playlist?.songs;
 
     if (!songs?.length) {
-      return await interaction.followUp(`**${playlistName}** is empty!`);
+      return await interaction.followUp(`:x: **${playlistName}** is empty!`);
     }
 
     if (location > songs.length || location < 0) {
-      return await interaction.followUp('Please enter a valid index!');
+      return await interaction.followUp(':x: Please enter a valid index!');
     }
 
     const id = songs[location - 1].id;
@@ -55,15 +55,15 @@ export class RemoveFromPlaylistCommand extends Command {
         }
       });
     } catch (error) {
-      return await interaction.followUp('Something went wrong!');
+      return await interaction.followUp(':x: Something went wrong!');
     }
 
     if (!song) {
-      return await interaction.followUp('Something went wrong!');
+      return await interaction.followUp(':x: Something went wrong!');
     }
 
     await interaction.followUp(
-      `Deleted **${song.name}** from **${playlistName}**`
+      `:wastebasket: Deleted **${song.name}** from **${playlistName}**`
     );
     return;
   }

--- a/src/commands/music/remove.ts
+++ b/src/commands/music/remove.ts
@@ -26,7 +26,7 @@ export class RemoveCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (position < 1 || position > player!.queue.tracks.length) {
-      return interaction.reply('Please enter a valid position number!');
+      return interaction.reply(':x: Please enter a valid position number!');
     }
 
     player!.queue.tracks.splice(position - 1, 1);

--- a/src/commands/music/resume.ts
+++ b/src/commands/music/resume.ts
@@ -1,3 +1,4 @@
+import { NowPlayingEmbed } from './../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
@@ -6,6 +7,10 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'resume',
@@ -28,8 +33,26 @@ export class PauseCommand extends Command {
       return await interaction.reply('The track is not paused!');
     }
 
-    player?.resume();
+    await player?.resume();
+
     clearTimeout(client.leaveTimers[player?.guildId!]);
+    await handlePlayerEmbed(player?.queue!);
+    const NowPlaying = new NowPlayingEmbed(
+      player?.queue.current!,
+      player?.accuratePosition,
+      player?.queue.current?.length as number,
+      player?.volume!,
+      player?.queue.tracks!,
+      player?.queue.last!,
+      player?.paused
+    );
+
+    await embedButtons(
+      NowPlaying.NowPlayingEmbed(),
+      player?.queue!,
+      player?.queue.current!
+    );
+
     return await interaction.reply('Track resumed playing');
   }
 

--- a/src/commands/music/resume.ts
+++ b/src/commands/music/resume.ts
@@ -7,10 +7,7 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'resume',
@@ -36,7 +33,6 @@ export class PauseCommand extends Command {
     await player?.resume();
 
     clearTimeout(client.leaveTimers[player?.guildId!]);
-    await handlePlayerEmbed(player?.queue!);
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,
       player?.accuratePosition,

--- a/src/commands/music/resume.ts
+++ b/src/commands/music/resume.ts
@@ -30,7 +30,7 @@ export class PauseCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (!player!.paused) {
-      return await interaction.reply('The track is not paused!');
+      return await interaction.reply(':x: The track is not paused!');
     }
 
     await player?.resume();

--- a/src/commands/music/resume.ts
+++ b/src/commands/music/resume.ts
@@ -29,6 +29,7 @@ export class PauseCommand extends Command {
     }
 
     player?.resume();
+    clearTimeout(client.leaveTimers[player?.guildId!]);
     return await interaction.reply('Track resumed playing');
   }
 

--- a/src/commands/music/save-to-playlist.ts
+++ b/src/commands/music/save-to-playlist.ts
@@ -57,7 +57,7 @@ export class SaveToPlaylistCommand extends Command {
 
       return await interaction.followUp(`Added tracks to **${playlistName}**`);
     } catch (error) {
-      return await interaction.followUp('Something went wrong!');
+      return await interaction.followUp(':x: Something went wrong!');
     }
   }
 

--- a/src/commands/music/seek.ts
+++ b/src/commands/music/seek.ts
@@ -1,3 +1,4 @@
+import { NowPlayingEmbed } from './../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
@@ -6,6 +7,10 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'seek',
@@ -31,6 +36,23 @@ export class SeekCommand extends Command {
     }
 
     await player?.seek(milliseconds);
+    await handlePlayerEmbed(player?.queue!);
+    const NowPlaying = new NowPlayingEmbed(
+      player?.queue.current!,
+      player?.accuratePosition,
+      player?.queue.current?.length as number,
+      player?.volume!,
+      player?.queue.tracks!,
+      player?.queue.last!,
+      player?.paused
+    );
+
+    await embedButtons(
+      NowPlaying.NowPlayingEmbed(),
+      player?.queue!,
+      player?.queue.current!
+    );
+
     return await interaction.reply(`Seeked to ${seconds} seconds`);
   }
 

--- a/src/commands/music/seek.ts
+++ b/src/commands/music/seek.ts
@@ -32,8 +32,10 @@ export class SeekCommand extends Command {
 
     const milliseconds = seconds * 1000;
     if (milliseconds > player!.queue!.current!.length || milliseconds < 0) {
-      return await interaction.reply('Please enter a valid number!');
+      return await interaction.reply(':x: Please enter a valid number!');
     }
+    if (!player?.queue.current?.isSeekable)
+      return await interaction.reply(":x: Can't use Seek on a Live Stream!");
 
     await player?.seek(milliseconds);
     await handlePlayerEmbed(player?.queue!);

--- a/src/commands/music/seek.ts
+++ b/src/commands/music/seek.ts
@@ -7,10 +7,7 @@ import {
 } from '@sapphire/framework';
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'seek',
@@ -38,7 +35,7 @@ export class SeekCommand extends Command {
       return await interaction.reply(":x: Can't use Seek on a Live Stream!");
 
     await player?.seek(milliseconds);
-    await handlePlayerEmbed(player?.queue!);
+
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,
       player?.accuratePosition,

--- a/src/commands/music/shuffle.ts
+++ b/src/commands/music/shuffle.ts
@@ -31,7 +31,7 @@ export class LeaveCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (!player?.queue.tracks.length) {
-      return await interaction.reply('There are no songs in queue!');
+      return await interaction.reply(':x: There are no songs in queue!');
     }
 
     shuffleQueue(player?.queue.tracks as Song[]);

--- a/src/commands/music/shuffle.ts
+++ b/src/commands/music/shuffle.ts
@@ -8,10 +8,7 @@ import {
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Song } from '../../lib/utils/queue/Song';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'shuffle',
@@ -36,7 +33,6 @@ export class LeaveCommand extends Command {
 
     shuffleQueue(player?.queue.tracks as Song[]);
 
-    await handlePlayerEmbed(player?.queue!);
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,
       player?.accuratePosition,

--- a/src/commands/music/shuffle.ts
+++ b/src/commands/music/shuffle.ts
@@ -1,3 +1,4 @@
+import { NowPlayingEmbed } from './../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
@@ -7,6 +8,10 @@ import {
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Song } from '../../lib/utils/queue/Song';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'shuffle',
@@ -30,6 +35,23 @@ export class LeaveCommand extends Command {
     }
 
     shuffleQueue(player?.queue.tracks as Song[]);
+
+    await handlePlayerEmbed(player?.queue!);
+    const NowPlaying = new NowPlayingEmbed(
+      player?.queue.current!,
+      player?.accuratePosition,
+      player?.queue.current?.length as number,
+      player?.volume!,
+      player?.queue.tracks!,
+      player?.queue.last!,
+      player?.paused
+    );
+
+    await embedButtons(
+      NowPlaying.NowPlayingEmbed(),
+      player?.queue!,
+      player?.queue.current!
+    );
 
     return await interaction.reply('Queue shuffled');
   }

--- a/src/commands/music/skip.ts
+++ b/src/commands/music/skip.ts
@@ -31,7 +31,7 @@ export class SkipCommand extends Command {
       player!.queue.tracks.unshift(player!.queue.current as Song);
     }
     await player?.queue.next();
-    if (player) handlePlayerEmbed(player.queue);
+    await handlePlayerEmbed(player?.queue!);
     return await interaction.reply('Skipped track');
   }
 

--- a/src/commands/music/skip.ts
+++ b/src/commands/music/skip.ts
@@ -8,7 +8,6 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Song } from '../../lib/utils/queue/Song';
 import { LoopType } from '../../lib/utils/queue/Queue';
-import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'skip',
@@ -31,7 +30,6 @@ export class SkipCommand extends Command {
       player!.queue.tracks.unshift(player!.queue.current as Song);
     }
     await player?.queue.next();
-    await handlePlayerEmbed(player?.queue!);
     return await interaction.reply('Skipped track');
   }
 

--- a/src/commands/music/skip.ts
+++ b/src/commands/music/skip.ts
@@ -8,6 +8,7 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Song } from '../../lib/utils/queue/Song';
 import { LoopType } from '../../lib/utils/queue/Queue';
+import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'skip',
@@ -30,6 +31,7 @@ export class SkipCommand extends Command {
       player!.queue.tracks.unshift(player!.queue.current as Song);
     }
     await player?.queue.next();
+    if (player) handlePlayerEmbed(player.queue);
     return await interaction.reply('Skipped track');
   }
 

--- a/src/commands/music/skipto.ts
+++ b/src/commands/music/skipto.ts
@@ -7,7 +7,7 @@ import {
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import { LoopType } from '../../lib/utils/queue/Queue';
-import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
+// import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'skipto',
@@ -39,9 +39,8 @@ export class SkipToCommand extends Command {
       player.queue.tracks.splice(0, position - 1);
       player.queue.setLoop(LoopType.None);
     }
-    player.queue.next();
+    await player.queue.next();
 
-    await handlePlayerEmbed(player.queue);
     return await interaction.reply(
       `Skipped to **${player.queue.current!.title}**`
     );

--- a/src/commands/music/skipto.ts
+++ b/src/commands/music/skipto.ts
@@ -7,6 +7,7 @@ import {
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import { LoopType } from '../../lib/utils/queue/Queue';
+import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'skipto',
@@ -38,8 +39,9 @@ export class SkipToCommand extends Command {
       player.queue.tracks.splice(0, position - 1);
       player.queue.setLoop(LoopType.None);
     }
-
     player.queue.next();
+
+    await handlePlayerEmbed(player.queue);
     return await interaction.reply(
       `Skipped to **${player.queue.current!.title}**`
     );

--- a/src/commands/music/skipto.ts
+++ b/src/commands/music/skipto.ts
@@ -28,7 +28,7 @@ export class SkipToCommand extends Command {
     const player = client.music.players.get(interaction.guild!.id);
 
     if (!player?.queue.tracks.length) {
-      return await interaction.reply('There are no tracks in queue!');
+      return await interaction.reply(':x: There are no tracks in queue!');
     }
 
     if (player.queue.loop.type == LoopType.Queue) {

--- a/src/commands/music/skipto.ts
+++ b/src/commands/music/skipto.ts
@@ -7,7 +7,6 @@ import {
 import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import { LoopType } from '../../lib/utils/queue/Queue';
-// import { handlePlayerEmbed } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'skipto',

--- a/src/commands/music/stop-trivia.ts
+++ b/src/commands/music/stop-trivia.ts
@@ -20,13 +20,13 @@ export class StopTriviaCommand extends Command {
 
     if (!player) {
       return await interaction.reply(
-        'There is no trivia playing at the moment!'
+        ':x: There is no trivia playing at the moment!'
       );
     }
 
     if (!player.triviaQueue.current) {
       return await interaction.reply(
-        'There is no trivia playing at the moment!'
+        ':x: There is no trivia playing at the moment!'
       );
     }
 

--- a/src/commands/music/volume.ts
+++ b/src/commands/music/volume.ts
@@ -9,10 +9,7 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Node, Player } from 'lavaclient';
 import prisma from '../../lib/prisma';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'volume',
@@ -56,7 +53,7 @@ export class VolumeCommand extends Command {
     }
 
     await player.setVolume(query);
-    await handlePlayerEmbed(player?.queue!);
+
     const NowPlaying = new NowPlayingEmbed(
       player?.queue.current!,
       player?.accuratePosition,
@@ -76,7 +73,9 @@ export class VolumeCommand extends Command {
     let volumeIcon: string = ':speaker:';
     if (vol > 50) volumeIcon = ':loud_sound:';
     if (vol <= 50 && vol > 20) volumeIcon = ':sound:';
-    return await interaction.reply(`Volume is now to ${query}% ${volumeIcon}`);
+    return await interaction.reply(
+      `Volume is now set to ${query}% ${volumeIcon}`
+    );
   }
 
   public override registerApplicationCommands(

--- a/src/commands/music/volume.ts
+++ b/src/commands/music/volume.ts
@@ -72,8 +72,11 @@ export class VolumeCommand extends Command {
       player?.queue!,
       player?.queue.current!
     );
-
-    return await interaction.reply(`Volume is now to ${query}%`);
+    const vol = query;
+    let volumeIcon: string = ':speaker:';
+    if (vol > 50) volumeIcon = ':loud_sound:';
+    if (vol <= 50 && vol > 20) volumeIcon = ':sound:';
+    return await interaction.reply(`Volume is now to ${query}% ${volumeIcon}`);
   }
 
   public override registerApplicationCommands(

--- a/src/commands/music/volume.ts
+++ b/src/commands/music/volume.ts
@@ -1,3 +1,4 @@
+import { NowPlayingEmbed } from './../../lib/utils/music/NowPlayingEmbed';
 import { ApplyOptions } from '@sapphire/decorators';
 import {
   ApplicationCommandRegistry,
@@ -8,6 +9,10 @@ import type { CommandInteraction } from 'discord.js';
 import { container } from '@sapphire/framework';
 import type { Node, Player } from 'lavaclient';
 import prisma from '../../lib/prisma';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../../lib/utils/music/ButtonHandler';
 
 @ApplyOptions<CommandOptions>({
   name: 'volume',
@@ -51,6 +56,23 @@ export class VolumeCommand extends Command {
     }
 
     await player.setVolume(query);
+    await handlePlayerEmbed(player?.queue!);
+    const NowPlaying = new NowPlayingEmbed(
+      player?.queue.current!,
+      player?.accuratePosition,
+      player?.queue.current?.length as number,
+      player?.volume!,
+      player?.queue.tracks!,
+      player?.queue.last!,
+      player?.paused
+    );
+
+    await embedButtons(
+      NowPlaying.NowPlayingEmbed(),
+      player?.queue!,
+      player?.queue.current!
+    );
+
     return await interaction.reply(`Volume is now to ${query}%`);
   }
 

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -43,6 +43,23 @@ export async function embedButtons(
       components: [row]
     })
     .then(async (message: Message) => {
+      if (client.playerEmbeds[message.guild!.id])
+        await message.channel
+          .fetch()
+          .then(
+            async channel =>
+              await channel.messages.fetch(
+                client.playerEmbeds[message.guild!.id]
+              )
+          )
+          .then(async oldMessage => {
+            await oldMessage
+              .delete()
+              .catch(error =>
+                console.log('Failed to Delete Old Message.', error)
+              );
+          });
+      client.playerEmbeds[message.guild!.id] = message.id;
       const player = client.music.players.get(message.guild!.id);
       const maxLimit = 1.8e6; // 30 minutes
 

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -110,14 +110,11 @@ export async function embedButtons(
               player?.disconnect();
               client.music.destroyPlayer(player.guildId);
               clearTimeout(timer);
-              // await handlePlayerEmbed(player.queue);
             }
             if (i.customId === 'next') {
               await i.update('Skipping');
               player.queue.next();
               clearTimeout(timer);
-              // await message.delete();
-              // await handlePlayerEmbed(player.queue);
             }
             if (i.customId === 'volumeUp') {
               const volume =
@@ -169,6 +166,7 @@ export async function embedButtons(
               await i.update({ embeds: [NowPlaying.NowPlayingEmbed()] });
             }
           });
+
           collector.on('end', async () => {
             clearTimeout(timer);
           });

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -17,6 +17,8 @@ export async function embedButtons(
   song: Song,
   message?: string
 ) {
+  await deletePlayerEmbed(queue);
+
   const { client } = container;
   const row = new MessageActionRow().addComponents(
     new MessageButton()
@@ -63,6 +65,7 @@ export async function embedButtons(
                   ':x: only available to members in the same voice channel',
                 ephemeral: true
               });
+
             let paused;
 
             if (i.customId === 'playPause') {
@@ -80,7 +83,7 @@ export async function embedButtons(
                 }, maxLimit);
 
                 timer = setTimeout(async () => {
-                  await handlePlayerEmbed(player.queue);
+                  await deletePlayerEmbed(player.queue);
                 }, maxLimit);
 
                 player.pause();
@@ -103,7 +106,7 @@ export async function embedButtons(
             }
             if (i.customId === 'stop') {
               await i.update('Leaving');
-              await handlePlayerEmbed(player.queue);
+              await deletePlayerEmbed(player.queue);
               player?.disconnect();
               client.music.destroyPlayer(player.guildId);
               clearTimeout(timer);
@@ -173,7 +176,7 @@ export async function embedButtons(
       }
     });
 }
-export async function handlePlayerEmbed(player: Queue) {
+export async function deletePlayerEmbed(player: Queue) {
   const { client } = container;
   if (client.playerEmbeds[player?.player.guildId]) {
     await player

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -59,7 +59,7 @@ export async function embedButtons(
       if (player) {
         try {
           collector.on('collect', async (i: MessageComponentInteraction) => {
-            if (message.member?.voice.channel?.members.has(i.user.id) === false)
+            if (!message.member?.voice.channel?.members.has(i.user.id))
               return await i.reply({
                 content:
                   ':x: only available to members in the same voice channel',
@@ -176,15 +176,15 @@ export async function embedButtons(
       }
     });
 }
-export async function deletePlayerEmbed(queue: Queue) {
+export async function deletePlayerEmbed(player: Queue) {
   const { client } = container;
-  if (client.playerEmbeds[queue?.player.guildId]) {
-    await queue
+  if (client.playerEmbeds[player?.player.guildId]) {
+    await player
       .channel!.fetch(true)
       .then(
         async channel =>
           await channel.messages.fetch(
-            client.playerEmbeds[queue?.player.guildId!]
+            client.playerEmbeds[player?.player.guildId!]
           )
       )
       .then(async oldMessage => {
@@ -194,7 +194,7 @@ export async function deletePlayerEmbed(queue: Queue) {
             .catch(error =>
               console.log('Failed to Delete Old Message.', error)
             );
-        delete client.playerEmbeds[queue?.player.guildId!];
+        delete client.playerEmbeds[player?.player.guildId!];
       });
   }
 }

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -59,17 +59,11 @@ export async function embedButtons(
 
       let timer: NodeJS.Timer; // still needed for Pause
 
-      // if (queue.tracks?.length > 2)
-      //   message.components[0].components[2].setDisabled(false);
-      // else message.components[0].components[2].setDisabled(true);
-
       if (player) {
         try {
           collector.on('collect', async (i: MessageComponentInteraction) => {
             let paused;
-            // if (queue.tracks?.length)
-            //   message.components[0].components[2].setDisabled(false);
-            // else message.components[0].components[2].setDisabled(false);
+
             if (i.customId === 'playPause') {
               clearTimeout(timer);
 

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -176,15 +176,15 @@ export async function embedButtons(
       }
     });
 }
-export async function deletePlayerEmbed(player: Queue) {
+export async function deletePlayerEmbed(queue: Queue) {
   const { client } = container;
-  if (client.playerEmbeds[player?.player.guildId]) {
-    await player
+  if (client.playerEmbeds[queue?.player.guildId]) {
+    await queue
       .channel!.fetch(true)
       .then(
         async channel =>
           await channel.messages.fetch(
-            client.playerEmbeds[player?.player.guildId!]
+            client.playerEmbeds[queue?.player.guildId!]
           )
       )
       .then(async oldMessage => {
@@ -194,7 +194,7 @@ export async function deletePlayerEmbed(player: Queue) {
             .catch(error =>
               console.log('Failed to Delete Old Message.', error)
             );
-        delete client.playerEmbeds[player?.player.guildId!];
+        delete client.playerEmbeds[queue?.player.guildId!];
       });
   }
 }

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -50,18 +50,19 @@ export async function embedButtons(
       const maxLimit = 1.8e6; // 30 minutes
       client.playerEmbeds[message.guildId ?? message.guild!.id] = message.id;
 
-      const filter = (message: any) =>
-        message.member?.voice.channel?.id === player?.channelId; // only available to members in the same voice channel
-
-      const collector = message.createMessageComponentCollector({
-        filter
-      });
+      const collector = message.createMessageComponentCollector();
 
       let timer: NodeJS.Timer; // still needed for Pause
 
       if (player) {
         try {
           collector.on('collect', async (i: MessageComponentInteraction) => {
+            if (message.member?.voice.channel?.members.has(i.user.id) === false)
+              return await i.reply({
+                content:
+                  ':x: only available to members in the same voice channel',
+                ephemeral: true
+              });
             let paused;
 
             if (i.customId === 'playPause') {

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -27,7 +27,8 @@ export async function embedButtons(
     new MessageButton()
       .setCustomId('next')
       .setLabel('Next')
-      .setStyle('PRIMARY'),
+      .setStyle('PRIMARY')
+      .setDisabled(!queue.tracks?.length ? true : false),
     new MessageButton()
       .setCustomId('volumeUp')
       .setLabel('Vol+')
@@ -58,17 +59,17 @@ export async function embedButtons(
 
       let timer: NodeJS.Timer; // still needed for Pause
 
-      if (queue.tracks?.length)
-        message.components[0].components[2].setDisabled(false);
-      else message.components[0].components[2].setDisabled(true);
+      // if (queue.tracks?.length > 2)
+      //   message.components[0].components[2].setDisabled(false);
+      // else message.components[0].components[2].setDisabled(true);
 
       if (player) {
         try {
           collector.on('collect', async (i: MessageComponentInteraction) => {
             let paused;
-            if (queue.tracks?.length)
-              message.components[0].components[2].setDisabled(false);
-            else message.components[0].components[2].setDisabled(false);
+            // if (queue.tracks?.length)
+            //   message.components[0].components[2].setDisabled(false);
+            // else message.components[0].components[2].setDisabled(false);
             if (i.customId === 'playPause') {
               clearTimeout(timer);
 

--- a/src/lib/utils/music/ButtonHandler.ts
+++ b/src/lib/utils/music/ButtonHandler.ts
@@ -107,6 +107,7 @@ export async function embedButtons(
             }
             if (i.customId === 'stop') {
               await i.update('Leaving');
+              await handlePlayerEmbed(player.queue);
               player?.disconnect();
               client.music.destroyPlayer(player.guildId);
               clearTimeout(timer);

--- a/src/lib/utils/music/handleOptions.ts
+++ b/src/lib/utils/music/handleOptions.ts
@@ -1,0 +1,29 @@
+import options from '../../../options.json';
+import type { Song } from '../queue/Song';
+
+export function inactivityTime() {
+  let response: number = 30000; // Default 30 seconds
+
+  if (!options) {
+    return response;
+  }
+  if (!options.inactivityTime) {
+    return response;
+  }
+  const savedOption = Number(options.inactivityTime);
+  if (savedOption < 0) return response;
+  if (Number.isInteger(savedOption)) {
+    response = savedOption * 1000;
+  }
+
+  response == 0 ? (response = 30000) : null;
+
+  return response;
+}
+
+export function shuffleQueue(queue: Song[]) {
+  for (let i = queue.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [queue[i], queue[j]] = [queue[j], queue[i]];
+  }
+}

--- a/src/lib/utils/queue/Queue.ts
+++ b/src/lib/utils/queue/Queue.ts
@@ -63,7 +63,7 @@ export class Queue extends TypedEmitter<QueueEvents> {
       this.emit('trackStart', this.current);
     });
 
-    player.on('trackEnd', async (_, reason) => {
+    player.on('trackEnd', (_, reason) => {
       if (!mayStartNext[reason]) return;
       this.last = this.current;
 

--- a/src/lib/utils/queue/Queue.ts
+++ b/src/lib/utils/queue/Queue.ts
@@ -14,8 +14,6 @@ import {
 import { mayStartNext, Track } from '@lavaclient/types';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import type { MessageChannel } from '../../..';
-import { handlePlayerEmbed } from '../music/ButtonHandler';
-
 export enum LoopType {
   None,
   Queue,
@@ -67,7 +65,6 @@ export class Queue extends TypedEmitter<QueueEvents> {
 
     player.on('trackEnd', async (_, reason) => {
       if (!mayStartNext[reason]) return;
-      await handlePlayerEmbed(player.queue);
       this.last = this.current;
 
       if (this.current) {

--- a/src/lib/utils/queue/Queue.ts
+++ b/src/lib/utils/queue/Queue.ts
@@ -14,6 +14,7 @@ import {
 import { mayStartNext, Track } from '@lavaclient/types';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import type { MessageChannel } from '../../..';
+import { handlePlayerEmbed } from '../music/ButtonHandler';
 
 export enum LoopType {
   None,
@@ -64,9 +65,9 @@ export class Queue extends TypedEmitter<QueueEvents> {
       this.emit('trackStart', this.current);
     });
 
-    player.on('trackEnd', (_, reason) => {
+    player.on('trackEnd', async (_, reason) => {
       if (!mayStartNext[reason]) return;
-
+      await handlePlayerEmbed(player.queue);
       this.last = this.current;
 
       if (this.current) {

--- a/src/lib/utils/queue/Song.ts
+++ b/src/lib/utils/queue/Song.ts
@@ -25,6 +25,18 @@ export class Song implements TrackInfo {
     this.track = typeof track === 'string' ? track : track.track;
     this.requester = requester;
     this.added = added ?? Date.now();
+    const filterSet = {
+      song: [
+        MetadataFilter.removeVersion,
+        MetadataFilter.removeRemastered,
+        MetadataFilter.fixTrackSuffix,
+        MetadataFilter.removeLive,
+        MetadataFilter.youtube,
+        MetadataFilter.normalizeFeature,
+        MetadataFilter.removeVersion
+      ]
+    };
+    const filter = MetadataFilter.createFilter(filterSet);
 
     // TODO: make this less shitty
     if (typeof track !== 'string') {
@@ -33,7 +45,7 @@ export class Song implements TrackInfo {
       this.author = track.info.author;
       this.isStream = track.info.isStream;
       this.position = track.info.position;
-      this.title = MetadataFilter.youtube(track.info.title);
+      this.title = filter.filterField('song', track.info.title);
       this.uri = track.info.uri;
       this.isSeekable = track.info.isSeekable;
       this.sourceName = track.info.sourceName;
@@ -45,7 +57,7 @@ export class Song implements TrackInfo {
       this.author = decoded.author;
       this.isStream = decoded.isStream;
       this.position = Number(decoded.position);
-      this.title = MetadataFilter.youtube(decoded.title);
+      this.title = filter.filterField('song', decoded.title);
       this.uri = decoded.uri!;
       this.isSeekable = !decoded.isStream;
       this.sourceName = decoded.source!;

--- a/src/lib/utils/queue/Song.ts
+++ b/src/lib/utils/queue/Song.ts
@@ -1,5 +1,6 @@
 import { decode } from '@lavalink/encoding';
 import type { Track, TrackInfo } from '@lavaclient/types';
+import * as MetadataFilter from 'metadata-filter';
 
 export class Song implements TrackInfo {
   readonly track: string;
@@ -32,7 +33,7 @@ export class Song implements TrackInfo {
       this.author = track.info.author;
       this.isStream = track.info.isStream;
       this.position = track.info.position;
-      this.title = track.info.title;
+      this.title = MetadataFilter.youtube(track.info.title);
       this.uri = track.info.uri;
       this.isSeekable = track.info.isSeekable;
       this.sourceName = track.info.sourceName;
@@ -44,7 +45,7 @@ export class Song implements TrackInfo {
       this.author = decoded.author;
       this.isStream = decoded.isStream;
       this.position = Number(decoded.position);
-      this.title = decoded.title;
+      this.title = MetadataFilter.youtube(decoded.title);
       this.uri = decoded.uri!;
       this.isSeekable = !decoded.isStream;
       this.sourceName = decoded.source!;

--- a/src/options.json
+++ b/src/options.json
@@ -1,0 +1,6 @@
+{
+  "playLiveStreams": true,
+  "playVideosLongerThan1Hour": true,
+  "maxQueueLength": 1000,
+  "inactivityTime": 30
+}

--- a/src/structures/ExtendedClient.ts
+++ b/src/structures/ExtendedClient.ts
@@ -50,7 +50,7 @@ export class ExtendedClient extends SapphireClient {
         queue.player.disconnect();
         queue.player.node.destroyPlayer(queue.player.guildId);
       }, inactivityTime());
-      delete this.playerEmbeds![queue.player.guildId];
+      delete this.playerEmbeds[queue.player.guildId];
     });
 
     this.music.on('trackStart', async (queue, song) => {

--- a/src/structures/ExtendedClient.ts
+++ b/src/structures/ExtendedClient.ts
@@ -2,12 +2,10 @@ import { SapphireClient } from '@sapphire/framework';
 import { Intents } from 'discord.js';
 import { Node } from 'lavaclient';
 import * as data from '../config.json';
-import {
-  embedButtons,
-  handlePlayerEmbed
-} from '../lib/utils/music/ButtonHandler';
+import { embedButtons } from '../lib/utils/music/ButtonHandler';
 import { NowPlayingEmbed } from './../lib/utils/music/NowPlayingEmbed';
 import { manageStageChannel } from './../lib/utils/music/channelHandler';
+import { inactivityTime } from '../lib/utils/music/handleOptions';
 
 export class ExtendedClient extends SapphireClient {
   readonly music: Node;
@@ -51,7 +49,7 @@ export class ExtendedClient extends SapphireClient {
         queue.channel!.send(':zzz: Leaving due to inactivity');
         queue.player.disconnect();
         queue.player.node.destroyPlayer(queue.player.guildId);
-      }, 30 * 1000);
+      }, inactivityTime());
       delete this.playerEmbeds![queue.player.guildId];
     });
 
@@ -60,7 +58,6 @@ export class ExtendedClient extends SapphireClient {
         clearTimeout(this.leaveTimers[queue.player.guildId]!);
       }
 
-      await handlePlayerEmbed(queue);
       const NowPlaying = new NowPlayingEmbed(
         song,
         0,
@@ -76,6 +73,7 @@ export class ExtendedClient extends SapphireClient {
       const voiceChannel = this.voice.client.channels.cache.get(
         queue.player.channelId!
       );
+
       // Stage Channels
       if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
         const botUser = voiceChannel?.members.get(this.application?.id!);

--- a/src/structures/ExtendedClient.ts
+++ b/src/structures/ExtendedClient.ts
@@ -2,7 +2,10 @@ import { SapphireClient } from '@sapphire/framework';
 import { Intents } from 'discord.js';
 import { Node } from 'lavaclient';
 import * as data from '../config.json';
-import { embedButtons } from '../lib/utils/music/ButtonHandler';
+import {
+  embedButtons,
+  handlePlayerEmbed
+} from '../lib/utils/music/ButtonHandler';
 import { NowPlayingEmbed } from './../lib/utils/music/NowPlayingEmbed';
 import { manageStageChannel } from './../lib/utils/music/channelHandler';
 
@@ -49,6 +52,7 @@ export class ExtendedClient extends SapphireClient {
         queue.player.disconnect();
         queue.player.node.destroyPlayer(queue.player.guildId);
       }, 30 * 1000);
+      delete this.playerEmbeds![queue.player.guildId];
     });
 
     this.music.on('trackStart', async (queue, song) => {
@@ -56,6 +60,7 @@ export class ExtendedClient extends SapphireClient {
         clearTimeout(this.leaveTimers[queue.player.guildId]!);
       }
 
+      await handlePlayerEmbed(queue);
       const NowPlaying = new NowPlayingEmbed(
         song,
         0,

--- a/src/structures/ExtendedClient.ts
+++ b/src/structures/ExtendedClient.ts
@@ -8,6 +8,7 @@ import { manageStageChannel } from './../lib/utils/music/channelHandler';
 
 export class ExtendedClient extends SapphireClient {
   readonly music: Node;
+  playerEmbeds: { [key: string]: string };
   leaveTimers: { [key: string]: NodeJS.Timer };
 
   public constructor() {
@@ -38,6 +39,7 @@ export class ExtendedClient extends SapphireClient {
       this.music.handleVoiceUpdate(data);
     });
 
+    this.playerEmbeds = {};
     this.leaveTimers = {};
     this.music.on('queueFinish', queue => {
       queue.player.stop();
@@ -81,6 +83,7 @@ export class ExtendedClient extends SapphireClient {
 declare module '@sapphire/framework' {
   interface SapphireClient {
     readonly music: Node;
+    playerEmbeds: { [key: string]: string };
     leaveTimers: { [key: string]: NodeJS.Timer };
   }
 }


### PR DESCRIPTION
- [x] Done https://github.com/galnir/Master-Bot/pull/705#pullrequestreview-969438525 

LOL i needed to take a break from the Twitch Feature Testing :D, so yeahhhhh

/play, /leave, /skip, /skipto, /seek, /pause /resume /volume and /now-playing will delete/alter the old Music Player Embed

Note: the Player Embed will always stay in the text channel that the Player was initiated in, even if you run a music command in a different text channel than the Embed, I figured it was better if the Embed didn't move from channel to channel


Tested/Compiled On
Windows 10 (Local)
Raspberry OS (Arm64 Local)
Debian 10 (Arm64 and x64 Local)


Much Love
-Bacon