### PR TITLE
Music Player - Minor Update

### DIFF
--- a/src/lib/utils/queue/Queue.ts
+++ b/src/lib/utils/queue/Queue.ts
@@ -14,6 +14,7 @@ import {
 import { mayStartNext, Track } from '@lavaclient/types';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import type { MessageChannel } from '../../..';
+import { deletePlayerEmbed } from '../music/ButtonHandler';
 export enum LoopType {
   None,
   Queue,
@@ -63,7 +64,7 @@ export class Queue extends TypedEmitter<QueueEvents> {
       this.emit('trackStart', this.current);
     });
 
-    player.on('trackEnd', (_, reason) => {
+    player.on('trackEnd', async (_, reason) => {
       if (!mayStartNext[reason]) return;
       this.last = this.current;
 
@@ -78,7 +79,7 @@ export class Queue extends TypedEmitter<QueueEvents> {
 
         this.emit('trackEnd', this.current);
       }
-
+      await deletePlayerEmbed(this.player.queue);
       if (!this.tracks.length) {
         this.tracks = this.previous;
         this.previous = [];

--- a/src/structures/ExtendedClient.ts
+++ b/src/structures/ExtendedClient.ts
@@ -57,8 +57,8 @@ export class ExtendedClient extends SapphireClient {
       });
 
       setInterval(() => {
-        this.twitch
-          .api?.getAccessToken('user:read:email')
+        this.twitch.api
+          ?.getAccessToken('user:read:email')
           .then(response => {
             this.twitch.auth = {
               access_token: response.access_token,
@@ -97,8 +97,19 @@ export class ExtendedClient extends SapphireClient {
     });
 
     this.music.on('trackStart', async (queue, song) => {
+      const channel = this.channels.cache.get(queue.player.channelId!);
+
       if (this.leaveTimers[queue.player.guildId]) {
         clearTimeout(this.leaveTimers[queue.player.guildId]!);
+      }
+      if (channel?.isVoice()) {
+        if (channel.members.size == 1) {
+          queue.channel!.send(':zzz: Leaving empty voice channel');
+          queue.player.disconnect();
+          queue.player.node.destroyPlayer(queue.player.guildId);
+          delete this.playerEmbeds[queue.player.guildId];
+          return;
+        }
       }
 
       const NowPlaying = new NowPlayingEmbed(


### PR DESCRIPTION
Update
- it will now check if it's about to stream music to an empty channel when a track starts, if there's only 1 member(the bot) it will leave, save on some bandwidth waste :)

Bugfix
- Fixed the "You're in the wrong channel! Join <#null>" when doing `/play` command after the bot was disconnected from the channel with the Right-Click->Disconnect method in discord, also deletes the last Player embed when the bot is d/c in this manner
- I forgot to delete the last embed when a queue is finished :(


Tested On
Windows 10 (Local DB)
Raspian OS (arm64/Local DB)
Debian 10 (arm64/x64/Local DB)

Much Love
-Bacon