### PR TITLE
Docker-Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Nextjs Files
+.next
+
+# Docker Files
+Dockerfile
+docker-compose.yml
+docker-compose.yaml
+.dockerignore
+
+# Git Files
+.git
+.github
+.gitignore
+LICENSE
+README.md
+
+# Node Modules and lint settings
+node_modules
+.prettierrc
+dist
+logs
+Lavalink.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
-FROM node:16-alpine
+FROM node:16-slim
 WORKDIR "/Master-Bot"
 
-# Install and register fonts (needed for Game Commands)
-RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \
-	update-ms-fonts && \
-	fc-cache -f && \
-	apk del fonts && \
-	find  /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; \
-	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root
+# Install prerequisites and register fonts
+RUN apt-get update && apt-get install -y -q openssl && apt-get install -y -q && apt-get install -y -q --no-install-recommends libfontconfig1
 
 # Copy files to Container (Excluding whats in .dockerignore)
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:16-alpine
+WORKDIR "/Master-Bot"
+
+# Install and register fonts (needed for Game Commands)
+RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \
+	update-ms-fonts && \
+	fc-cache -f && \
+	apk del fonts && \
+	find  /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; \
+	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root
+
+# Copy files to Container (Excluding whats in .dockerignore)
+COPY ./ ./
+
+# Install for Docker-Compose (Excluding "postinstall")
+RUN npm ci --development --ignore-scripts
+RUN ["npx", "prisma", "generate", "dev"]
+
+# Install for Standalone Dockerfile use (comment out the 2 lines above and uncomment the line below)
+# RUN npm ci --development 
+
+# Ports for the Dashboard  
+EXPOSE 3000
+ENV PORT 3000
+
+# Stop Nextjs Data Collection
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Run Concurrent Start Script
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+services:
+  master-bot:
+    env_file:
+      - docker.env
+    restart: always
+    build: .
+    ports:
+      - "3000:3000" # Dashboard
+      # - "5555:5555" # Prisma Studio Port  - uncomment to open
+    command: >
+      sh -c "npx prisma db push && npm run dev"
+    depends_on:
+      lavalink:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Password is required and must match '.env' file
+      POSTGRES_DB_NAME: ${POSTGRES_DB_NAME} # Must match '.env' file
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST} # Must match '.env' file
+      REDIS_HOST: ${REDIS_HOST} # Must match service name
+      REDIS_PORT: ${REDIS_PORT}
+      REDIS_DB: ${REDIS_DB}
+    links:
+      - lavalink
+      - redis
+      - postgres
+    volumes:
+      - ./logs:/Master-Bot/packages/bot/logs
+  lavalink:
+    restart: always
+    image: fredboat/lavalink:dev
+    healthcheck:
+      test: "echo lavalink"
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+  postgres:
+    env_file:
+      - docker.env
+    image: postgres:14.1-alpine
+    restart: always
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB_NAME=${POSTGRES_DB_NAME}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  redis:
+    env_file:
+      - docker.env
+    image: redis:6.2-alpine
+    restart: always
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_DB=${REDIS_DB}
+    command: redis-server --save 20 1 --loglevel warning
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - redis:/data
+volumes:
+  postgres:
+    driver: local
+  redis:
+    driver: local

--- a/docker.env
+++ b/docker.env
@@ -4,7 +4,7 @@
  # run "docker compose --env-file docker.env up -d --build" in root folder
  
  # Prisma Override
- DATABASE_URL="postgresql://postgresUsername:postgresPassword@postgres:5432/master-bot?schema=public"
+ DATABASE_URL="postgresql://postgresUsername:postgresPassword@postgres:5432/master-bot?schema=public&connect_timeout=300"
 
  # LavaLink Docker Container
  LAVA_HOST="lavalink"

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,26 @@
+ # Editing this file is not required and used for Docker-Compose Only
+ # these will overwrite the needed .env variables to create and link ALL the containers correctly
+ # Fill out your .env as normal then to dockerize   
+ # run "docker compose --env-file docker.env up -d --build" in root folder
+ 
+ # Prisma Override
+ DATABASE_URL="postgresql://postgresUsername:postgresPassword@postgres:5432/master-bot?schema=public"
+
+ # LavaLink Docker Container
+ LAVA_HOST="lavalink"
+ LAVA_PASS="youshallnotpass"
+ LAVA_PORT=2333
+ LAVA_SECURE=false
+
+ # Postgres Docker Container
+ POSTGRES_HOST="postgres" 
+ POSTGRES_USER="postgresUsername"
+ POSTGRES_PORT=5432
+ POSTGRES_PASSWORD="postgresPassword"
+ POSTGRES_DB_NAME="master-bot"
+
+ # Redis Docker Container
+ REDIS_HOST="redis" 
+ REDIS_PORT=6379
+ REDIS_DB=0
+ REDIS_PASSWORD="redisPassword"

--- a/packages/bot/src/structures/ExtendedClient.ts
+++ b/packages/bot/src/structures/ExtendedClient.ts
@@ -45,7 +45,14 @@ export class ExtendedClient extends SapphireClient {
     this.music = new QueueClient({
       sendGatewayPayload: (id, payload) =>
         this.guilds.cache.get(id)?.shard?.send(payload),
-      options: { redis: new Redis() },
+      options: {
+        redis: new Redis({
+          host: process.env.REDIS_HOST || 'localhost',
+          port: Number.parseInt(process.env.REDIS_PORT!) || 6379,
+          password: process.env.REDIS_PASSWORD || '',
+          db: Number.parseInt(process.env.REDIS_DB!) || 0
+        })
+      },
       connection: {
         host: process.env.LAVA_HOST || '',
         password: process.env.LAVA_PASS || '',


### PR DESCRIPTION
Post Updated 8/31/2022
Docker compose Implementation

there is a premade `docker.env`(editing it is not required, but the option is there), that will override the Prisma, and Lavalink variables to make everything happy and simple to deploy all the supporting services and Master-Bot

### How to use

example below is start to finish for getting all the services and master-bot going (postgres/redis/lavalink/dashboard)

- install Docker Desktop
- create your `application.yml` file
- fill out your `.env` file as normal
- run `docker compose --env-file docker.env up -d --build` in root folder
- enjoy

### How to handle Master-Bot updates

if the containers are already made and there has been an update to Master-Bot

- clone/pull repo
- run `docker compose --env-file docker.env up -d --build` <br>
  Also addresses #735
  the following can be added to the `.env` if they wish to use them (not required)

```
 REDIS_HOST="redisHostPath"
 REDIS_PORT=6379
 REDIS_DB=0
 REDIS_PASSWORD="redisPassword"
```

Side Note

- you can expose port "5555:5555" in the "docker-compose.yml" then run `npx prisma studio` inside the bot's docker container to manage the Database with a nice web interface at localhost:5555
- Bot logs are outputted to the `./logs/` folder (outside of container) for debugging

### **Updated** Test Results ([a07b25b](https://github.com/galnir/Master-Bot/pull/742/commits/a07b25bd9303b158f921f38da7853c74655f10aa))

| **OS**        | **Arch** | **Nodejs** | **Docker** | **Compose**                                                                                      |
| ------------- | -------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------ |
| Windows 10/11 | x64      | pass       | pass       | supported                                                                                        |
| Debian        | x64      | pass       | pass       | supported                                                                                        |
| Raspian 64    | Arm64    | pass       | pass       | [unofficial support](https://www.jfrog.com/connect/post/install-docker-compose-on-raspberry-pi/) |
| Debian        | Arm64    | pass       | pass       | supported                                                                                        |
| Ubuntu 21.10  | Arm64    | pass       | pass       | supported                                                                                        |
| Manjaro       | Arm64    | pass       | pass       | unofficial support (arch install)                                                                |

All Arm64 Tests were done on a Pi4b 4, 6, and 8 gig models,

Note: 4gig model dosen't have enough ram to run all services and master-bot containers, so i recommend 6gigs or higher if you decide to go that route

Much Love
-Bacon
