### PR TITLE
dashboard - welcome channels patch 1

### DIFF
--- a/packages/api/src/routers/channel.ts
+++ b/packages/api/src/routers/channel.ts
@@ -22,8 +22,8 @@ export const channelRouter = createRouter().query("get-all", {
     );
     const responseChannels: APIGuildChannel<any>[] = await response.json();
 
-    const channels: APIGuildTextChannel<2>[] = responseChannels.filter(
-      (channel) => channel.type === 2
+    const channels: APIGuildTextChannel<0>[] = responseChannels.filter(
+      (channel) => channel.type === 0
     );
     return { channels };
   },


### PR DESCRIPTION
noticed that the channels that were listed for the welcome message channel were only voice channels

2 (Voice channel) -> 0 (Text channels)

Much Love
-Bacon