### PR TITLE
Dashboard - guild selection Ui tweak

### DIFF
--- a/packages/dashboard/src/components/GuildSelectBox/GuildSelectBox.tsx
+++ b/packages/dashboard/src/components/GuildSelectBox/GuildSelectBox.tsx
@@ -8,29 +8,54 @@ interface GuildSelectBoxProps {
   id: string;
 }
 
+const allowInvite =
+  env.NEXT_PUBLIC_ALLOW_NEW_GUILDS.toLowerCase() == "true" ? true : false;
+
 const GuildSelectBox = ({ img, name, isBotIn, id }: GuildSelectBoxProps) => {
   return (
     <div className="flex flex-col gap-4">
       <div className="max-w-xs">
-        <img className="rounded-2xl w-52" src={img} alt="guild banner" />
+        <h1
+          className={
+            "rounded-t-md text-center shadow-inner shadow-slate-900" +
+            (isBotIn ? " bg-green-700" : " bg-gray-500")
+          }
+        >
+          {name}
+        </h1>
+        <img
+          className={
+            "rounded-b-md w-52 mx-auto d-block " +
+            (isBotIn ? "grayscale-0" : "grayscale")
+          }
+          src={img}
+          alt="guild banner"
+        />
       </div>
-      <div className="text-white flex justify-between">
-        <h1>{name}</h1>
+      <div className="text-white flex justify-center">
         {isBotIn ? (
           <Link href={`/dashboard/${id}`}>
-            <button className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700">
-              {isBotIn ? "Go" : "Invite"}
+            <button className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700 shadow shadow-slate-900">
+              {"Manage"}
             </button>
           </Link>
-        ) : (
+        ) : allowInvite ? (
           <a
-            className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700"
+            className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700 shadow shadow-slate-900 "
             href={env.NEXT_PUBLIC_INVITE_URL}
             target="_blank"
             rel="noreferrer"
           >
-            Invite
+            {"Invite"}
           </a>
+        ) : (
+          <button
+            className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700 shadow shadow-slate-700 opacity-50 cursor-not-allowed"
+            disabled
+            title="Currently Not Accepting New Invites"
+          >
+            {"Invite Disabled"}
+          </button>
         )}
       </div>
     </div>

--- a/packages/dashboard/src/components/Logo/Logo.tsx
+++ b/packages/dashboard/src/components/Logo/Logo.tsx
@@ -1,8 +1,10 @@
 const Logo = () => {
   return (
-    <h1 className="font-bold text-transparent w-max text-6xl bg-clip-text bg-gradient-to-r from-red-600 to-amber-500">
-      <span>Master Bot</span>
-    </h1>
+    <a href="/">
+      <h1 className="font-bold text-transparent w-max text-6xl bg-clip-text bg-gradient-to-r from-red-600 to-amber-500">
+        <span>Master Bot</span>
+      </h1>
+    </a>
   );
 };
 

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -19,6 +19,7 @@ export const serverSchema = z.object({
  */
 export const clientSchema = z.object({
   NEXT_PUBLIC_INVITE_URL: z.string().url(),
+  NEXT_PUBLIC_ALLOW_NEW_GUILDS: z.string(),
 });
 
 /**
@@ -29,4 +30,6 @@ export const clientSchema = z.object({
  */
 export const clientEnv = {
   NEXT_PUBLIC_INVITE_URL: process.env.NEXT_PUBLIC_INVITE_URL,
+  NEXT_PUBLIC_ALLOW_NEW_GUILDS:
+    process.env.NEXT_PUBLIC_ALLOW_NEW_GUILDS ?? "true",
 };

--- a/packages/dashboard/src/pages/dashboard/index.tsx
+++ b/packages/dashboard/src/pages/dashboard/index.tsx
@@ -3,7 +3,10 @@ import Head from "next/head";
 import { getServerSession } from "../../shared/get-server-session";
 import { trpc } from "../../utils/trpc";
 import GuildSelectBox from "../../components/GuildSelectBox";
+import { env } from "../../env/client.mjs";
 
+const allowInvite =
+  env.NEXT_PUBLIC_ALLOW_NEW_GUILDS.toLowerCase() == "true" ? true : false;
 const DashboardIndexPage: NextPage = () => {
   const { data } = trpc.useQuery(["guild.get-all"]);
 
@@ -13,26 +16,38 @@ const DashboardIndexPage: NextPage = () => {
         <title>Choose Guild</title>
         <meta name="description" content="Choose guild to manage screen" />
       </Head>
-      <main className="p-10">
+      <main className="p-10 bg-slate-900">
         <h1 className="text-3xl mb-4">Choose guild to manage</h1>
         {data?.apiGuilds ? (
-          <div className="flex gap-10">
+          <div className="flex flex-wrap gap-10">
             {data?.apiGuilds.map((guild) => {
               const isBotInGuild = data.dbGuilds.some(
                 (dbGuild) => dbGuild.id === guild.id
               );
               return (
-                <GuildSelectBox
-                  key={guild.id}
-                  img={
-                    guild.icon
-                      ? `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`
-                      : "generic-image.png"
+                <div
+                  key={`${guild.id}`}
+                  className={
+                    "fluid bg-slate-500 bg-opacity-25 shadow-md shadow-slate-900 rounded-md" +
+                    (isBotInGuild
+                      ? " opacity-100"
+                      : allowInvite
+                      ? " opacity-75"
+                      : " opacity-20 cursor-not-allowed grayscale")
                   }
-                  name={guild.name}
-                  isBotIn={isBotInGuild}
-                  id={guild.id}
-                />
+                >
+                  <GuildSelectBox
+                    key={guild.id}
+                    img={
+                      guild.icon
+                        ? `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`
+                        : "generic-image.png"
+                    }
+                    name={guild.name}
+                    isBotIn={isBotInGuild}
+                    id={guild.id}
+                  />
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
Notice there wasn't a way to stop the use of the invite button if you try and host a public url but want to stop the bot from being added to more servers (Public but closed to invites)

i apologize for any goofs, I'm new to React, nextjs, and tailwind and the only other web stack I have used was Express with Pug

Visual Tweaks of the guild selection screen
visual indicators, shadows, and guild "frames" auto wrap to next row

![invitable](https://user-images.githubusercontent.com/12632936/188045805-b25e5a54-759c-4b3b-859f-ab57e4554c54.png)

you can add `NEXT_PUBLIC_ALLOW_NEW_GUILDS=false`  in the `.env` to disable the invite button (if variable not present in `env` it defaults to `true`)

![not invitable](https://user-images.githubusercontent.com/12632936/188046701-ebd0e3cf-0bae-4e5a-b1cc-622be63211aa.png)

Tested on
Brave (pc/mobile*)
Edge (pc)
Chrome (pc/mobile*)
Firefox (pc/mobile*)

mobile* - Home Page background color doesn't fill the page entirely (this issue is present pre- and post- PR changes on mobile devices)

Much Love
-Bacon