### PR TITLE
:recycle: Add support for NEXTAUTH_URL_INTERNAL` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ DISCORD_TOKEN=""
 # Next Auth
 
 NEXTAUTH_SECRET="somesupersecrettwelvelengthword"
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL="http://<public_server_ip>:3000"
+NEXTAUTH_URL_INTERNAL="http://0.0.0.0:3000"
 NEXT_PUBLIC_INVITE_URL="https://discord.com/api/oauth2/authorize?client_id=yourclientid&permissions=8&scope=bot"
 
 # Next Auth Discord Provider
@@ -98,10 +99,10 @@ Change 'john' to your pc username and 'doe' to some password, or set the name an
 Generate a token in your Discord developer portal.
 
 #### Next Auth
-You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id.
+Change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and change the `<public_server_ip>` in the `NEXTAUTH_URL` to your public IPv4 IP. You can find your public IP via the `Find Your IP` link in the links below if you are hosting on your own system. If you are hosting on a VPs, the public IP is your VPS IP.
 
 #### Next Auth Discord Provider
-Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set this as the URL under 'Redirects': http://localhost:3000/api/auth/callback/discord.
+Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, add these URLs under 'Redirects': `http://<public_server_ip>:3000/api/auth/callback/discord` and `http://0.0.0.0:3000/api/auth/callback/discord`.
 
 #### Lavalink
 You can leave this as long as the values match your application.yml.
@@ -211,6 +212,10 @@ A full list of commands for use with Master Bot
 [Using a public LavaLink server](https://github.com/galnir/Master-Bot/wiki/Setting-Up-LavaLink-with-a-public-LavaLink-Server)
 
 [Using an Internal LavaLink server](https://github.com/galnir/Master-Bot/wiki/Setting-up-LavaLink-with-an-Internal-LavaLink-server)
+
+[Find Your Public IP](https://whatismyipaddress.com/)
+
+[NextAuth Configuration Options](https://next-auth.js.org/configuration/options)
 
 ## Contributing
 

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -8,7 +8,7 @@ import { z } from "zod";
 export const serverSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
-  NEXTAUTH_URL_INTERNAL: z.string().url(),
+  NEXTAUTH_URL_INTERNAL: z.string().url().optional(),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -8,6 +8,7 @@ import { z } from "zod";
 export const serverSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
+  NEXTAUTH_URL_INTERNAL: z.string().url(),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });


### PR DESCRIPTION
 * Update `packages/dashboard/src/env/schema.mjs`
 * Add `NEXTAUTH_URL_INTERNAL` to the `.env`
 * Update instructions and links appropriately.
 
 
 This update will allow people to load the dashboard from the public IP and the internal IP. This way if they are hosting on their own machines they can have access it without having to use a different system on a different network.
 
 With this there are two connection IPs. There is the public one accessible by others and the Internal IP only accessible from the host machine.
 
 Both work perfectly with this update. Naturally though with this method if you want to access it form a seperate machine on the same network you will need to change the `NEXTAUTH_URL_INTERNAL="http://0.0.0.0:3000"` to `NEXTAUTH_URL_INTERNAL="http://<private_ip>:3000"` as `localhost` would not work for that.
 
 For instance if your private IP was `192.168.0.29` the `NEXTAUTH_URL_INTERNAL` flag would need to be set to `NEXTAUTH_URL_INTERNAL="http://192.168.0.29:3000"`
 
 Naturally you can see a description of this in the issue linked below:
 
 * #749 