### PR TITLE
Add NEXTAUTH_URL_INTERNAL option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ DATABASE_URL="postgresql://john:doe@localhost:5432/master-bot?schema=public"
 DISCORD_TOKEN=""
 
 NEXTAUTH_SECRET="somesupersecrettwelvelengthword"
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=
+NEXTAUTH_URL_INTERNAL=http://localhost:3000
 NEXT_PUBLIC_INVITE_URL="https://discord.com/api/oauth2/authorize?client_id=yourclientid&permissions=8&scope=bot"
 
 # Next Auth Discord Provider

--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ Change 'john' to your pc username and 'doe' to some password, or set the name an
 Generate a token in your Discord developer portal.
 
 #### Next Auth
-You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change `domain` in `NEXTAUTH_URL` to your domain or public ip. You can find you public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
+You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change 'domain' in NEXTAUTH_URL to your domain or public ip. You can find you public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
 
 #### Next Auth Discord Provider
-Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set the following reditrect URLs 'Redirects':
+Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set the following URLs under 'Redirects':
 
- * `http://localhost:3000/api/auth/callback/discord`
- * `http://domain:3000/api/auth/callback/discord`
+ * http://localhost:3000/api/auth/callback/discord
+ * http://domain:3000/api/auth/callback/discord
 
-Make sure to change `domain` in `http://domain:3000/api/auth/callback/discord` to your domain or public ip.
+Make sure to change 'domain' in http://domain:3000/api/auth/callback/discord to your domain or public ip.
 
 #### Lavalink
 You can leave this as long as the values match your application.yml.
@@ -119,7 +119,7 @@ Create an application in each platform's developer portal and paste the relevant
 1. If you followed everything right, hit `npm i` in the root folder. When it finishes make sure prisma didn't error.
 2. Open a separate terminal in the root folder and run 'java -jar Lavalink.jar'.
 3. Wait a few seconds and hit `npm run dev`.
-4. If everything works, your bot should be running and the dashboard should be on localhost:3000.
+4. If everything works, your bot and dashboard should be running.
 5. Enjoy!
 
 # Commands

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ DISCORD_TOKEN=""
 # Next Auth
 
 NEXTAUTH_SECRET="somesupersecrettwelvelengthword"
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://domian:3000
+NEXTAUTH_URL_INTERNAL=http://localhost:3000
 NEXT_PUBLIC_INVITE_URL="https://discord.com/api/oauth2/authorize?client_id=yourclientid&permissions=8&scope=bot"
 
 # Next Auth Discord Provider
@@ -98,10 +99,15 @@ Change 'john' to your pc username and 'doe' to some password, or set the name an
 Generate a token in your Discord developer portal.
 
 #### Next Auth
-You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id.
+You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change `domain` in `NEXTAUTH_URL` to your domain or public ip. You can find you public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
 
 #### Next Auth Discord Provider
-Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set this as the URL under 'Redirects': http://localhost:3000/api/auth/callback/discord.
+Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set the following reditrect URLs 'Redirects':
+
+ * `http://localhost:3000/api/auth/callback/discord`
+ * `http://domain:3000/api/auth/callback/discord`
+
+Make sure to change `domain` in `http://domain:3000/api/auth/callback/discord` to your domain or public ip.
 
 #### Lavalink
 You can leave this as long as the values match your application.yml.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Change 'john' to your pc username and 'doe' to some password, or set the name an
 Generate a token in your Discord developer portal.
 
 #### Next Auth
-You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change 'domain' in NEXTAUTH_URL to your domain or public ip. You can find you public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
+You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change 'domain' in NEXTAUTH_URL to your domain or public ip. You can find your public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
 
 #### Next Auth Discord Provider
 Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set the following URLs under 'Redirects':

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -8,7 +8,7 @@ import { z } from "zod";
 export const serverSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
-  NEXTAUTH_URL_INTERNAL: z.string().url(),
+  NEXTAUTH_URL_INTERNAL: z.string().url().default("http://localhost:3000"),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -8,6 +8,7 @@ import { z } from "zod";
 export const serverSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
+  NEXTAUTH_URL_INTERNAL: z.string().url(),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });


### PR DESCRIPTION
Fix for the private ip vs public ip problem in the dashboard. 
All I had to do to fix this was change the following section in `packages\dashboard\src\env\schema.mjs`.

```mjs
export const serverSchema = z.object({
  NEXTAUTH_SECRET: z.string(),
  NEXTAUTH_URL: z.string().url(),
  NEXTAUTH_URL_INTERNAL: z.string().url(),
  DISCORD_CLIENT_ID: z.string(),
  DISCORD_CLIENT_SECRET: z.string(),
});
```
With this we can now set the following environment variables in the `.env` file:


**With the Public Domain or IP**
```ini
NEXTAUTH_URL=http://domain:3000
NEXTAUTH_URL_INTERNAL=http://localhost:3000
```

**Without the Public Domain or IP**
```ini
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_URL_INTERNAL=http://localhost:3000
```

---

A working example of this would be as follows:

```ini
NEXTAUTH_URL=http://72.222.170.15:3000
NEXTAUTH_URL_INTERNAL=http://localhost:3000
```

---

Here is the page where I found this fix at if it helps.

 - https://next-auth.js.org/configuration/options