### PR TITLE
Reminders - TRPC v10

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "arrowParens": "avoid"
+}

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ Getting Postgres and Prisma to work together on Windows is not worth the hassle.
 ### Redis
 
 #### MacOS
+
 `brew install redis`.
 
 #### Windows
+
 Download from [here](https://redis.io/download/).
 
 #### Linux
+
 Follow the instructions [here](https://redis.io/docs/getting-started/installation/install-redis-on-linux/).
 
 ### Settings (env)
@@ -89,33 +92,42 @@ GENIUS_API=""
 RAWG_API=""
 
 ```
+
 #### Gif features
+
 If you have no use in the gif commands, leave everything under 'Other APIs' empty. Same applies for Twitch, everything else is needed.
 
 #### DB URL
+
 Change 'john' to your pc username and 'doe' to some password, or set the name and password you created when you installed Postgres.
 
 #### Bot Token
+
 Generate a token in your Discord developer portal.
 
 #### Next Auth
+
 You can leave everything as is, just change 'yourclientid' in NEXT_PUBLIC_INVITE_URL to your Discord bot id and then change 'domain' in NEXTAUTH_URL to your domain or public ip. You can find your public ip by going to [www.whatismyip.com](https://www.whatismyip.com/).
 
 #### Next Auth Discord Provider
+
 Go to the OAuth2 tab in the developer portal, copy the Client ID to DISCORD_CLIENT_ID and generate a secret to place in DISCORD_CLIENT_SECRET. Also, set the following URLs under 'Redirects':
 
- * http://localhost:3000/api/auth/callback/discord
- * http://domain:3000/api/auth/callback/discord
+- http://localhost:3000/api/auth/callback/discord
+- http://domain:3000/api/auth/callback/discord
 
 Make sure to change 'domain' in http://domain:3000/api/auth/callback/discord to your domain or public ip.
 
 #### Lavalink
+
 You can leave this as long as the values match your application.yml.
 
 #### Spotify and Twitch
+
 Create an application in each platform's developer portal and paste the relevant values.
 
 # Running the bot
+
 1. If you followed everything right, hit `npm i` in the root folder. When it finishes make sure prisma didn't error.
 2. Open a separate terminal in the root folder and run 'java -jar Lavalink.jar'.
 3. Wait a few seconds and hit `npm run dev`.
@@ -173,7 +185,6 @@ A full list of commands for use with Master Bot
 
 ## Other
 
-
 | Command           | Description                                                                                                                                                        | Usage                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
 | /fortune          | Get a fortune cookie tip                                                                                                                                           | /fortune                                |
@@ -225,9 +236,7 @@ Anyone is welcome to suggest new features and improve code quality!
 
 ## Contributors ❤️
 
-
 **⭐ [Bacon Fixation](https://github.com/Bacon-Fixation) ⭐ - Countless contributions**
-
 
 [ModoSN](https://github.com/ModoSN) - 'resolve-ip', 'rps', '8ball', 'bored', 'trump', 'advice', 'kanye', 'urban dictionary' commands and visual updates
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: always
     build: .
     ports:
-      - "3000:3000" # Dashboard
+      - '3000:3000' # Dashboard
       # - "5555:5555" # Prisma Studio Port  - uncomment to open
     command: >
       sh -c "npx prisma db push && npm run dev"
@@ -35,7 +35,7 @@ services:
     restart: always
     image: fredboat/lavalink:dev
     healthcheck:
-      test: "echo lavalink"
+      test: 'echo lavalink'
     volumes:
       - ./application.yml:/opt/Lavalink/application.yml
   postgres:
@@ -45,7 +45,7 @@ services:
     restart: always
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB_NAME}"]
+        ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB_NAME}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -67,7 +67,7 @@ services:
       - REDIS_DB=${REDIS_DB}
     command: redis-server --save 20 1 --loglevel warning
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
       timeout: 10s
       retries: 3

--- a/packages/api/src/createContext.ts
+++ b/packages/api/src/createContext.ts
@@ -1,10 +1,10 @@
 // src/server/router/context.ts
-import * as trpc from "@trpc/server";
-import * as trpcNext from "@trpc/server/adapters/next";
-import { Session } from "next-auth";
-import { unstable_getServerSession as getServerSession } from "next-auth";
-import { authOptions as nextAuthOptions } from "../../dashboard/src/pages/api/auth/[...nextauth]";
-import { prisma } from "./db/client";
+import * as trpc from '@trpc/server';
+import * as trpcNext from '@trpc/server/adapters/next';
+import { Session } from 'next-auth';
+import { unstable_getServerSession as getServerSession } from 'next-auth';
+import { authOptions as nextAuthOptions } from '../../dashboard/src/pages/api/auth/[...nextauth]';
+import { prisma } from './db/client';
 
 type CreateContextOptions = {
   session: Session | null;
@@ -17,7 +17,7 @@ type CreateContextOptions = {
 export const createContextInner = async (opts: CreateContextOptions) => {
   return {
     session: opts.session,
-    prisma,
+    prisma
   };
 };
 
@@ -31,7 +31,7 @@ export const createContext = async (
   const session = await getServerSession(opts.req, opts.res, nextAuthOptions);
 
   return await createContextInner({
-    session,
+    session
   });
 };
 

--- a/packages/api/src/db/client.ts
+++ b/packages/api/src/db/client.ts
@@ -1,5 +1,5 @@
 // src/server/db/client.ts
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
 declare global {
   var prisma: PrismaClient | undefined;
@@ -8,9 +8,9 @@ declare global {
 export const prisma =
   global.prisma ||
   new PrismaClient({
-    log: ["query"],
+    log: ['query']
   });
 
-if (process.env.NODE_ENV !== "production") {
+if (process.env.NODE_ENV !== 'production') {
   global.prisma = prisma;
 }

--- a/packages/api/src/routers/channel.ts
+++ b/packages/api/src/routers/channel.ts
@@ -1,12 +1,12 @@
-import { t } from "../trpc";
-import { z } from "zod";
-import { APIGuildChannel, APIGuildTextChannel } from "discord-api-types/v10";
+import { t } from '../trpc';
+import { z } from 'zod';
+import { APIGuildChannel, APIGuildTextChannel } from 'discord-api-types/v10';
 
 export const channelRouter = t.router({
   getAll: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({ input }) => {
@@ -19,15 +19,15 @@ export const channelRouter = t.router({
         `https://discordapp.com/api/guilds/${guildId}/channels`,
         {
           headers: {
-            Authorization: `Bot ${token}`,
-          },
+            Authorization: `Bot ${token}`
+          }
         }
       );
       const responseChannels: APIGuildChannel<any>[] = await response.json();
 
       const channels: APIGuildTextChannel<0>[] = responseChannels.filter(
-        (channel) => channel.type === 0
+        channel => channel.type === 0
       );
       return { channels };
-    }),
+    })
 });

--- a/packages/api/src/routers/command.ts
+++ b/packages/api/src/routers/command.ts
@@ -1,6 +1,6 @@
-import { t } from "../trpc";
-import { z } from "zod";
-import { TRPCError } from "@trpc/server";
+import { t } from '../trpc';
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 
 type CommandType = {
   id: string;
@@ -19,7 +19,7 @@ export const commandRouter = t.router({
   getDisabledCommands: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -27,17 +27,17 @@ export const commandRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
+          id: guildId
         },
         select: {
-          disabledCommands: true,
-        },
+          disabledCommands: true
+        }
       });
 
       if (!guild) {
         throw new TRPCError({
-          message: "Guild not found",
-          code: "NOT_FOUND",
+          message: 'Guild not found',
+          code: 'NOT_FOUND'
         });
       }
 
@@ -46,7 +46,7 @@ export const commandRouter = t.router({
   getCommands: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({}) => {
@@ -56,8 +56,8 @@ export const commandRouter = t.router({
           `https://discordapp.com/api/applications/${process.env.DISCORD_CLIENT_ID}/commands`,
           {
             headers: {
-              Authorization: `Bot ${token}`,
-            },
+              Authorization: `Bot ${token}`
+            }
           }
         );
         const commands: CommandType[] = await response.json();
@@ -66,8 +66,8 @@ export const commandRouter = t.router({
       } catch (e) {
         console.error(e);
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Something went wrong when trying to fetch guilds",
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Something went wrong when trying to fetch guilds'
         });
       }
     }),
@@ -76,7 +76,7 @@ export const commandRouter = t.router({
       z.object({
         guildId: z.string(),
         commandId: z.string(),
-        status: z.boolean(),
+        status: z.boolean()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -84,17 +84,17 @@ export const commandRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
+          id: guildId
         },
         select: {
-          disabledCommands: true,
-        },
+          disabledCommands: true
+        }
       });
 
       if (!guild) {
         throw new TRPCError({
-          message: "Guild not found",
-          code: "NOT_FOUND",
+          message: 'Guild not found',
+          code: 'NOT_FOUND'
         });
       }
 
@@ -103,27 +103,27 @@ export const commandRouter = t.router({
       if (status) {
         updatedGuild = await ctx.prisma.guild.update({
           where: {
-            id: guildId,
+            id: guildId
           },
           data: {
             disabledCommands: {
-              set: [...guild?.disabledCommands, commandId],
-            },
-          },
+              set: [...guild?.disabledCommands, commandId]
+            }
+          }
         });
       } else {
         updatedGuild = await ctx.prisma.guild.update({
           where: {
-            id: guildId,
+            id: guildId
           },
           data: {
             disabledCommands: {
-              set: guild?.disabledCommands.filter((cid) => cid !== commandId),
-            },
-          },
+              set: guild?.disabledCommands.filter(cid => cid !== commandId)
+            }
+          }
         });
       }
 
       return { updatedGuild };
-    }),
+    })
 });

--- a/packages/api/src/routers/guild.ts
+++ b/packages/api/src/routers/guild.ts
@@ -1,13 +1,13 @@
-import { t } from "../trpc";
-import { z } from "zod";
-import { APIGuild } from "discord-api-types/v10";
-import { TRPCError } from "@trpc/server";
+import { t } from '../trpc';
+import { z } from 'zod';
+import { APIGuild } from 'discord-api-types/v10';
+import { TRPCError } from '@trpc/server';
 
 export const guildRouter = t.router({
   getGuild: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -15,8 +15,8 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id,
-        },
+          id
+        }
       });
 
       return { guild };
@@ -24,7 +24,7 @@ export const guildRouter = t.router({
   getGuildAndUser: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -32,21 +32,21 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id,
-        },
+          id
+        }
       });
 
       const user = await ctx.prisma.user.findUnique({
         where: {
           // @ts-ignore
-          id: ctx.session?.user?.id,
-        },
+          id: ctx.session?.user?.id
+        }
       });
 
       if (guild?.ownerId !== user?.discordId) {
         throw new TRPCError({
-          message: "UNAUTHORIZED",
-          code: "UNAUTHORIZED",
+          message: 'UNAUTHORIZED',
+          code: 'UNAUTHORIZED'
         });
       }
 
@@ -57,7 +57,7 @@ export const guildRouter = t.router({
       z.object({
         id: z.string(),
         ownerId: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -65,15 +65,15 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.upsert({
         where: {
-          id: id,
+          id: id
         },
         update: {},
         create: {
           id: id,
           ownerId: ownerId,
           volume: 100,
-          name: name,
-        },
+          name: name
+        }
       });
 
       return { guild };
@@ -85,7 +85,7 @@ export const guildRouter = t.router({
         userId: z.string(),
         ownerId: z.string(),
         name: z.string(),
-        notifyList: z.array(z.string()),
+        notifyList: z.array(z.string())
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -96,19 +96,19 @@ export const guildRouter = t.router({
           notifyList: [userId],
           volume: 100,
           ownerId: ownerId,
-          name: name,
+          name: name
         },
         select: { notifyList: true },
         update: {
-          notifyList,
+          notifyList
         },
-        where: { id: guildId },
+        where: { id: guildId }
       });
     }),
   delete: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -116,8 +116,8 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.delete({
         where: {
-          id: id,
-        },
+          id: id
+        }
       });
 
       return { guild };
@@ -127,7 +127,7 @@ export const guildRouter = t.router({
       z.object({
         guildId: z.string(),
         welcomeMessage: z.string().nullable(),
-        welcomeMessageEnabled: z.boolean().nullable(),
+        welcomeMessageEnabled: z.boolean().nullable()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -135,15 +135,15 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
           // undefined means do nothing, null will set the value to null
           welcomeMessage: welcomeMessage ? welcomeMessage : undefined,
           welcomeMessageEnabled: welcomeMessageEnabled
             ? welcomeMessageEnabled
-            : undefined,
-        },
+            : undefined
+        }
       });
 
       return { guild };
@@ -152,7 +152,7 @@ export const guildRouter = t.router({
     .input(
       z.object({
         status: z.boolean(),
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -160,11 +160,11 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
-          welcomeMessageEnabled: status,
-        },
+          welcomeMessageEnabled: status
+        }
       });
 
       return { guild };
@@ -173,7 +173,7 @@ export const guildRouter = t.router({
     .input(
       z.object({
         guildId: z.string(),
-        channelId: z.string(),
+        channelId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -181,11 +181,11 @@ export const guildRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
-          welcomeMessageChannel: channelId,
-        },
+          welcomeMessageChannel: channelId
+        }
       });
 
       return { guild };
@@ -193,7 +193,7 @@ export const guildRouter = t.router({
   getAllFromLocal: t.procedure
     .input(
       z.object({
-        ownerId: z.string(),
+        ownerId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -201,8 +201,8 @@ export const guildRouter = t.router({
 
       const guilds = await ctx.prisma.guild.findMany({
         where: {
-          ownerId: ownerId as string,
-        },
+          ownerId: ownerId as string
+        }
       });
 
       return { guilds };
@@ -210,92 +210,92 @@ export const guildRouter = t.router({
   getAll: t.procedure.query(async ({ ctx }) => {
     if (!ctx.session) {
       throw new TRPCError({
-        message: "Not Authenticated",
-        code: "UNAUTHORIZED",
+        message: 'Not Authenticated',
+        code: 'UNAUTHORIZED'
       });
     }
 
     const account = await ctx.prisma.account.findFirst({
       where: {
         // @ts-ignore
-        userId: ctx.session?.user?.id,
+        userId: ctx.session?.user?.id
       },
       select: {
         access_token: true,
-        providerAccountId: true,
-      },
+        providerAccountId: true
+      }
     });
 
     if (!account || !account.access_token) {
       throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Account not found",
+        code: 'NOT_FOUND',
+        message: 'Account not found'
       });
     }
 
     const dbGuilds = await ctx.prisma.guild.findMany({
       where: {
-        ownerId: account.providerAccountId,
-      },
+        ownerId: account.providerAccountId
+      }
     });
 
     // fetch guilds the user is owner in from discord api using the ownerId and token
     try {
       const response = await fetch(`https://discord.com/api/users/@me/guilds`, {
         headers: {
-          Authorization: `Bearer ${account.access_token}`,
-        },
+          Authorization: `Bearer ${account.access_token}`
+        }
       });
 
       const userGuilds: APIGuild[] = await response.json();
       if (!userGuilds.length) {
         return { guilds: dbGuilds };
       }
-      const guildsUserOwns = userGuilds.filter((guild) => guild.owner);
+      const guildsUserOwns = userGuilds.filter(guild => guild.owner);
       return { apiGuilds: guildsUserOwns, dbGuilds };
     } catch (e) {
       console.error(e);
       throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Something went wrong when trying to fetch guilds",
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Something went wrong when trying to fetch guilds'
       });
     }
   }),
   getAllFromDiscordAPI: t.procedure.query(async ({ ctx }) => {
     if (!ctx.session) {
       throw new TRPCError({
-        message: "Not Authenticated",
-        code: "UNAUTHORIZED",
+        message: 'Not Authenticated',
+        code: 'UNAUTHORIZED'
       });
     }
 
     const account = await ctx.prisma.account.findFirst({
       where: {
         // @ts-ignore
-        userId: ctx.session?.user?.id,
+        userId: ctx.session?.user?.id
       },
       select: {
         access_token: true,
         providerAccountId: true,
         user: {
           select: {
-            discordId: true,
-          },
-        },
-      },
+            discordId: true
+          }
+        }
+      }
     });
 
     if (!account || !account.access_token) {
       throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Account not found",
+        code: 'NOT_FOUND',
+        message: 'Account not found'
       });
     }
 
     const response = await fetch(`https://discord.com/api/users/@me/guilds`, {
       headers: {
-        Authorization: `Bearer ${account.access_token}`,
-      },
+        Authorization: `Bearer ${account.access_token}`
+      }
     });
 
     const userGuilds: APIGuild[] = await response.json();
@@ -306,7 +306,7 @@ export const guildRouter = t.router({
     .input(
       z.object({
         guildId: z.string(),
-        notifyList: z.array(z.string()),
+        notifyList: z.array(z.string())
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -314,14 +314,14 @@ export const guildRouter = t.router({
 
       await ctx.prisma.guild.update({
         where: { id: guildId },
-        data: { notifyList },
+        data: { notifyList }
       });
     }),
   updateVolume: t.procedure
     .input(
       z.object({
         guildId: z.string(),
-        volume: z.number(),
+        volume: z.number()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -329,7 +329,7 @@ export const guildRouter = t.router({
 
       await ctx.prisma.guild.update({
         where: { id: guildId },
-        data: { volume },
+        data: { volume }
       });
-    }),
+    })
 });

--- a/packages/api/src/routers/hub.ts
+++ b/packages/api/src/routers/hub.ts
@@ -1,13 +1,13 @@
-import { t } from "../trpc";
-import { z } from "zod";
-import { TRPCError } from "@trpc/server";
+import { t } from '../trpc';
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 
 export const hubRouter = t.router({
   create: t.procedure
     .input(
       z.object({
         guildId: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -21,21 +21,21 @@ export const hubRouter = t.router({
           {
             headers: {
               Authorization: `Bot ${token}`,
-              "Content-Type": "application/json",
+              'Content-Type': 'application/json'
             },
-            method: "POST",
+            method: 'POST',
             body: JSON.stringify({
               name,
-              type: 4,
-            }),
+              type: 4
+            })
           }
         );
         parent = await response.json();
       } catch (e) {
         console.log(e);
         throw new TRPCError({
-          message: "Could not create channel",
-          code: "INTERNAL_SERVER_ERROR",
+          message: 'Could not create channel',
+          code: 'INTERNAL_SERVER_ERROR'
         });
       }
 
@@ -46,42 +46,42 @@ export const hubRouter = t.router({
           {
             headers: {
               Authorization: `Bot ${token}`,
-              "Content-Type": "application/json",
+              'Content-Type': 'application/json'
             },
-            method: "POST",
+            method: 'POST',
             body: JSON.stringify({
-              name: "Join To Create",
+              name: 'Join To Create',
               type: 2,
-              parent_id: parent.id,
-            }),
+              parent_id: parent.id
+            })
           }
         );
         hubChannel = await response.json();
       } catch {
         throw new TRPCError({
-          message: "Could not create channel",
-          code: "INTERNAL_SERVER_ERROR",
+          message: 'Could not create channel',
+          code: 'INTERNAL_SERVER_ERROR'
         });
       }
 
       const updatedGuild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
           hub: parent.id,
-          hubChannel: hubChannel.id,
-        },
+          hubChannel: hubChannel.id
+        }
       });
 
       return {
-        guild: updatedGuild,
+        guild: updatedGuild
       };
     }),
   delete: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -91,18 +91,18 @@ export const hubRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
+          id: guildId
         },
         select: {
           hub: true,
-          hubChannel: true,
-        },
+          hubChannel: true
+        }
       });
 
       if (!guild) {
         throw new TRPCError({
-          message: "Guild not found",
-          code: "NOT_FOUND",
+          message: 'Guild not found',
+          code: 'NOT_FOUND'
         });
       }
 
@@ -110,32 +110,32 @@ export const hubRouter = t.router({
         Promise.all([
           fetch(`https://discordapp.com/api/channels/${guild.hubChannel}`, {
             headers: {
-              Authorization: `Bot ${token}`,
+              Authorization: `Bot ${token}`
             },
-            method: "DELETE",
+            method: 'DELETE'
           }),
           fetch(`https://discordapp.com/api/channels/${guild.hub}`, {
             headers: {
-              Authorization: `Bot ${token}`,
+              Authorization: `Bot ${token}`
             },
-            method: "DELETE",
-          }),
+            method: 'DELETE'
+          })
         ]).then(async () => {
           await ctx.prisma.guild.update({
             where: {
-              id: guildId,
+              id: guildId
             },
             data: {
               hub: null,
-              hubChannel: null,
-            },
+              hubChannel: null
+            }
           });
         });
       } catch (e) {
         console.log(e);
         throw new TRPCError({
-          message: "Could not delete channel",
-          code: "INTERNAL_SERVER_ERROR",
+          message: 'Could not delete channel',
+          code: 'INTERNAL_SERVER_ERROR'
         });
       }
     }),
@@ -143,7 +143,7 @@ export const hubRouter = t.router({
     .input(
       z.object({
         guildId: z.string(),
-        ownerId: z.string(),
+        ownerId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -152,8 +152,8 @@ export const hubRouter = t.router({
       const tempChannel = await ctx.prisma.tempChannel.findFirst({
         where: {
           guildId,
-          ownerId,
-        },
+          ownerId
+        }
       });
 
       return { tempChannel };
@@ -163,7 +163,7 @@ export const hubRouter = t.router({
       z.object({
         guildId: z.string(),
         ownerId: z.string(),
-        channelId: z.string(),
+        channelId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -173,8 +173,8 @@ export const hubRouter = t.router({
         data: {
           guildId,
           ownerId,
-          id: channelId,
-        },
+          id: channelId
+        }
       });
 
       return { tempChannel };
@@ -182,7 +182,7 @@ export const hubRouter = t.router({
   deleteTempChannel: t.procedure
     .input(
       z.object({
-        channelId: z.string(),
+        channelId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -190,10 +190,10 @@ export const hubRouter = t.router({
 
       const tempChannel = await ctx.prisma.tempChannel.delete({
         where: {
-          id: channelId,
-        },
+          id: channelId
+        }
       });
 
       return { tempChannel };
-    }),
+    })
 });

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,15 +1,15 @@
-import { t } from "../trpc";
+import { t } from '../trpc';
 
-import { userRouter } from "./user";
-import { guildRouter } from "./guild";
-import { playlistRouter } from "./playlist";
-import { songRouter } from "./song";
-import { twitchRouter } from "./twitch";
-import { channelRouter } from "./channel";
-import { welcomeRouter } from "./welcome";
-import { commandRouter } from "./command";
-import { hubRouter } from "./hub";
-import { reminderRouter } from "./reminder";
+import { userRouter } from './user';
+import { guildRouter } from './guild';
+import { playlistRouter } from './playlist';
+import { songRouter } from './song';
+import { twitchRouter } from './twitch';
+import { channelRouter } from './channel';
+import { welcomeRouter } from './welcome';
+import { commandRouter } from './command';
+import { hubRouter } from './hub';
+import { reminderRouter } from './reminder';
 
 /**
  * Create your application's root router
@@ -28,7 +28,7 @@ export const appRouter = t.router({
   welcome: welcomeRouter,
   command: commandRouter,
   hub: hubRouter,
-  reminder: reminderRouter,
+  reminder: reminderRouter
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -9,6 +9,7 @@ import { channelRouter } from "./channel";
 import { welcomeRouter } from "./welcome";
 import { commandRouter } from "./command";
 import { hubRouter } from "./hub";
+import { reminderRouter } from "./reminder";
 
 /**
  * Create your application's root router
@@ -27,6 +28,7 @@ export const appRouter = t.router({
   welcome: welcomeRouter,
   command: commandRouter,
   hub: hubRouter,
+  reminder: reminderRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/playlist.ts
+++ b/packages/api/src/routers/playlist.ts
@@ -1,12 +1,12 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 
 export const playlistRouter = t.router({
   getPlaylist: t.procedure
     .input(
       z.object({
         userId: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -15,11 +15,11 @@ export const playlistRouter = t.router({
       const playlist = await ctx.prisma.playlist.findFirst({
         where: {
           userId,
-          name,
+          name
         },
         include: {
-          songs: true,
-        },
+          songs: true
+        }
       });
 
       return { playlist };
@@ -27,7 +27,7 @@ export const playlistRouter = t.router({
   getAll: t.procedure
     .input(
       z.object({
-        userId: z.string(),
+        userId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -35,14 +35,14 @@ export const playlistRouter = t.router({
 
       const playlists = await ctx.prisma.playlist.findMany({
         where: {
-          userId,
+          userId
         },
         include: {
-          songs: true,
+          songs: true
         },
         orderBy: {
-          id: "asc",
-        },
+          id: 'asc'
+        }
       });
 
       return { playlists };
@@ -51,7 +51,7 @@ export const playlistRouter = t.router({
     .input(
       z.object({
         userId: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -62,10 +62,10 @@ export const playlistRouter = t.router({
           name,
           user: {
             connect: {
-              id: userId,
-            },
-          },
-        },
+              id: userId
+            }
+          }
+        }
       });
 
       return { playlist };
@@ -74,7 +74,7 @@ export const playlistRouter = t.router({
     .input(
       z.object({
         userId: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -83,10 +83,10 @@ export const playlistRouter = t.router({
       const playlist = await ctx.prisma.playlist.deleteMany({
         where: {
           userId,
-          name,
-        },
+          name
+        }
       });
 
       return { playlist };
-    }),
+    })
 });

--- a/packages/api/src/routers/reminder.ts
+++ b/packages/api/src/routers/reminder.ts
@@ -1,5 +1,5 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 export const reminderRouter = t.router({
   getAll: t.procedure.query(async ({ ctx }) => {
     const reminders = await ctx.prisma.reminder.findMany();
@@ -10,7 +10,7 @@ export const reminderRouter = t.router({
     .input(
       z.object({
         userId: z.string(),
-        event: z.string(),
+        event: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -19,9 +19,9 @@ export const reminderRouter = t.router({
       const reminder = await ctx.prisma.reminder.findFirst({
         where: {
           userId,
-          event,
+          event
         },
-        include: { user: true },
+        include: { user: true }
       });
 
       return { reminder };
@@ -29,7 +29,7 @@ export const reminderRouter = t.router({
   getByUserId: t.procedure
     .input(
       z.object({
-        userId: z.string(),
+        userId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -37,16 +37,16 @@ export const reminderRouter = t.router({
 
       const reminders = await ctx.prisma.reminder.findMany({
         where: {
-          userId,
+          userId
         },
         select: {
           event: true,
           dateTime: true,
-          description: true,
+          description: true
         },
         orderBy: {
-          id: "asc",
-        },
+          id: 'asc'
+        }
       });
 
       return { reminders };
@@ -59,7 +59,7 @@ export const reminderRouter = t.router({
         description: z.nullable(z.string()),
         dateTime: z.string(),
         repeat: z.nullable(z.string()),
-        timeOffset: z.number(),
+        timeOffset: z.number()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -73,8 +73,8 @@ export const reminderRouter = t.router({
           dateTime,
           repeat,
           timeOffset,
-          user: { connect: { discordId: userId } },
-        },
+          user: { connect: { discordId: userId } }
+        }
       });
 
       return { reminder };
@@ -83,7 +83,7 @@ export const reminderRouter = t.router({
     .input(
       z.object({
         userId: z.string(),
-        event: z.string(),
+        event: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -92,10 +92,10 @@ export const reminderRouter = t.router({
       const reminder = await ctx.prisma.reminder.deleteMany({
         where: {
           userId,
-          event,
-        },
+          event
+        }
       });
 
       return { reminder };
-    }),
+    })
 });

--- a/packages/api/src/routers/reminder.ts
+++ b/packages/api/src/routers/reminder.ts
@@ -1,0 +1,101 @@
+import { t } from "../trpc";
+import { z } from "zod";
+export const reminderRouter = t.router({
+  getAll: t.procedure.query(async ({ ctx }) => {
+    const reminders = await ctx.prisma.reminder.findMany();
+
+    return { reminders };
+  }),
+  getReminder: t.procedure
+    .input(
+      z.object({
+        userId: z.string(),
+        event: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId, event } = input;
+
+      const reminder = await ctx.prisma.reminder.findFirst({
+        where: {
+          userId,
+          event,
+        },
+        include: { user: true },
+      });
+
+      return { reminder };
+    }),
+  getByUserId: t.procedure
+    .input(
+      z.object({
+        userId: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId } = input;
+
+      const reminders = await ctx.prisma.reminder.findMany({
+        where: {
+          userId,
+        },
+        select: {
+          event: true,
+          dateTime: true,
+          description: true,
+        },
+        orderBy: {
+          id: "asc",
+        },
+      });
+
+      return { reminders };
+    }),
+  create: t.procedure
+    .input(
+      z.object({
+        userId: z.string(),
+        event: z.string(),
+        description: z.nullable(z.string()),
+        dateTime: z.string(),
+        repeat: z.nullable(z.string()),
+        timeOffset: z.number(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId, event, description, dateTime, repeat, timeOffset } =
+        input;
+
+      const reminder = await ctx.prisma.reminder.create({
+        data: {
+          event,
+          description,
+          dateTime,
+          repeat,
+          timeOffset,
+          user: { connect: { discordId: userId } },
+        },
+      });
+
+      return { reminder };
+    }),
+  delete: t.procedure
+    .input(
+      z.object({
+        userId: z.string(),
+        event: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId, event } = input;
+
+      const reminder = await ctx.prisma.reminder.deleteMany({
+        where: {
+          userId,
+          event,
+        },
+      });
+
+      return { reminder };
+    }),
+});

--- a/packages/api/src/routers/song.ts
+++ b/packages/api/src/routers/song.ts
@@ -1,18 +1,18 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 
 export const songRouter = t.router({
   createMany: t.procedure
     .input(
       z.object({
-        songs: z.array(z.any()),
+        songs: z.array(z.any())
       })
     )
     .mutation(async ({ ctx, input }) => {
       const { songs } = input;
 
       const songsCreated = await ctx.prisma.song.createMany({
-        data: songs,
+        data: songs
       });
 
       return { songsCreated };
@@ -20,7 +20,7 @@ export const songRouter = t.router({
   delete: t.procedure
     .input(
       z.object({
-        id: z.number(),
+        id: z.number()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -28,10 +28,10 @@ export const songRouter = t.router({
 
       const song = await ctx.prisma.song.delete({
         where: {
-          id: id,
-        },
+          id: id
+        }
       });
 
       return { song };
-    }),
+    })
 });

--- a/packages/api/src/routers/twitch.ts
+++ b/packages/api/src/routers/twitch.ts
@@ -1,5 +1,5 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 
 export const twitchRouter = t.router({
   getAll: t.procedure.query(async ({ ctx }) => {
@@ -10,7 +10,7 @@ export const twitchRouter = t.router({
   findUserById: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -18,8 +18,8 @@ export const twitchRouter = t.router({
 
       const notification = await ctx.prisma.twitchNotify.findFirst({
         where: {
-          twitchId: id,
-        },
+          twitchId: id
+        }
       });
 
       return { notification };
@@ -30,7 +30,7 @@ export const twitchRouter = t.router({
         userId: z.string(),
         userImage: z.string(),
         channelId: z.string(),
-        sendTo: z.array(z.string()),
+        sendTo: z.array(z.string())
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -40,17 +40,17 @@ export const twitchRouter = t.router({
           twitchId: userId,
           channelIds: [channelId],
           logo: userImage,
-          sent: false,
+          sent: false
         },
         update: { channelIds: sendTo },
-        where: { twitchId: userId },
+        where: { twitchId: userId }
       });
     }),
   updateNotification: t.procedure
     .input(
       z.object({
         userId: z.string(),
-        channelIds: z.array(z.string()),
+        channelIds: z.array(z.string())
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -58,11 +58,11 @@ export const twitchRouter = t.router({
 
       const notification = await ctx.prisma.twitchNotify.update({
         where: {
-          twitchId: userId,
+          twitchId: userId
         },
         data: {
-          channelIds,
-        },
+          channelIds
+        }
       });
 
       return { notification };
@@ -70,7 +70,7 @@ export const twitchRouter = t.router({
   delete: t.procedure
     .input(
       z.object({
-        userId: z.string(),
+        userId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -78,8 +78,8 @@ export const twitchRouter = t.router({
 
       const notification = await ctx.prisma.twitchNotify.delete({
         where: {
-          twitchId: userId,
-        },
+          twitchId: userId
+        }
       });
 
       return { notification };
@@ -89,7 +89,7 @@ export const twitchRouter = t.router({
       z.object({
         userId: z.string(),
         live: z.boolean(),
-        sent: z.boolean(),
+        sent: z.boolean()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -97,9 +97,9 @@ export const twitchRouter = t.router({
 
       const notification = await ctx.prisma.twitchNotify.update({
         where: { twitchId: userId },
-        data: { live, sent },
+        data: { live, sent }
       });
 
       return { notification };
-    }),
+    })
 });

--- a/packages/api/src/routers/user.ts
+++ b/packages/api/src/routers/user.ts
@@ -1,11 +1,11 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 
 export const userRouter = t.router({
   getUserById: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -13,8 +13,8 @@ export const userRouter = t.router({
 
       const user = await ctx.prisma.user.findUnique({
         where: {
-          discordId: id,
-        },
+          discordId: id
+        }
       });
 
       return { user };
@@ -23,27 +23,27 @@ export const userRouter = t.router({
     .input(
       z.object({
         id: z.string(),
-        name: z.string(),
+        name: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
       const { id, name } = input;
       const user = await ctx.prisma.user.upsert({
         where: {
-          discordId: id,
+          discordId: id
         },
         update: {},
         create: {
           discordId: id,
-          name,
-        },
+          name
+        }
       });
       return { user };
     }),
   delete: t.procedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -51,8 +51,8 @@ export const userRouter = t.router({
 
       const user = await ctx.prisma.user.delete({
         where: {
-          discordId: id,
-        },
+          discordId: id
+        }
       });
 
       return { user };
@@ -61,19 +61,19 @@ export const userRouter = t.router({
     .input(
       z.object({
         id: z.string(),
-        timeOffset: z.number(),
+        timeOffset: z.number()
       })
     )
     .mutation(async ({ ctx, input }) => {
       const { id, timeOffset } = input;
       const userTime = await ctx.prisma.user.update({
         where: {
-          discordId: id,
+          discordId: id
         },
         data: { timeOffset: timeOffset },
-        select: { timeOffset: true },
+        select: { timeOffset: true }
       });
 
       return { userTime };
-    }),
+    })
 });

--- a/packages/api/src/routers/user.ts
+++ b/packages/api/src/routers/user.ts
@@ -57,4 +57,23 @@ export const userRouter = t.router({
 
       return { user };
     }),
+  updateTimeOffset: t.procedure
+    .input(
+      z.object({
+        id: z.string(),
+        timeOffset: z.number(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { id, timeOffset } = input;
+      const userTime = await ctx.prisma.user.update({
+        where: {
+          discordId: id,
+        },
+        data: { timeOffset: timeOffset },
+        select: { timeOffset: true },
+      });
+
+      return { userTime };
+    }),
 });

--- a/packages/api/src/routers/welcome.ts
+++ b/packages/api/src/routers/welcome.ts
@@ -1,11 +1,11 @@
-import { t } from "../trpc";
-import { z } from "zod";
+import { t } from '../trpc';
+import { z } from 'zod';
 
 export const welcomeRouter = t.router({
   getMessage: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -13,19 +13,19 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
-        },
+          id: guildId
+        }
       });
 
       return {
-        message: guild?.welcomeMessage,
+        message: guild?.welcomeMessage
       };
     }),
   setMessage: t.procedure
     .input(
       z.object({
         message: z.string().min(4).max(100),
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -33,11 +33,11 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
-          welcomeMessage: message,
-        },
+          welcomeMessage: message
+        }
       });
 
       return { guild };
@@ -46,7 +46,7 @@ export const welcomeRouter = t.router({
     .input(
       z.object({
         channelId: z.string(),
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -54,11 +54,11 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
-          welcomeMessageChannel: channelId,
-        },
+          welcomeMessageChannel: channelId
+        }
       });
 
       return { guild };
@@ -66,7 +66,7 @@ export const welcomeRouter = t.router({
   getChannel: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -74,11 +74,11 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
+          id: guildId
         },
         select: {
-          welcomeMessageChannel: true,
-        },
+          welcomeMessageChannel: true
+        }
       });
 
       return { guild };
@@ -86,7 +86,7 @@ export const welcomeRouter = t.router({
   getStatus: t.procedure
     .input(
       z.object({
-        guildId: z.string(),
+        guildId: z.string()
       })
     )
     .query(async ({ ctx, input }) => {
@@ -94,11 +94,11 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.findUnique({
         where: {
-          id: guildId,
+          id: guildId
         },
         select: {
-          welcomeMessageEnabled: true,
-        },
+          welcomeMessageEnabled: true
+        }
       });
 
       return { guild };
@@ -107,7 +107,7 @@ export const welcomeRouter = t.router({
     .input(
       z.object({
         guildId: z.string(),
-        status: z.boolean(),
+        status: z.boolean()
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -115,13 +115,13 @@ export const welcomeRouter = t.router({
 
       const guild = await ctx.prisma.guild.update({
         where: {
-          id: guildId,
+          id: guildId
         },
         data: {
-          welcomeMessageEnabled: status,
-        },
+          welcomeMessageEnabled: status
+        }
       });
 
       return { guild };
-    }),
+    })
 });

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -1,7 +1,7 @@
-import { initTRPC } from "@trpc/server";
-import type { Context } from "./createContext";
-import superjson from "superjson";
+import { initTRPC } from '@trpc/server';
+import type { Context } from './createContext';
+import superjson from 'superjson';
 
 export const t = initTRPC.context<Context>().create({
-  transformer: superjson,
+  transformer: superjson
 });

--- a/packages/bot/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/packages/bot/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,10 +4,9 @@ about: Create a report
 title: ''
 labels: 'bug'
 assignees: ''
-
 ---
 
-### IMPORTANT : *DO NOT SKIP THIS STEPS AND DO NOT DELETE THEM. WE CAN NOT HELP YOU IF YOU DO NOT PROVIDE INFORMATION AND STEPS TO REPRODUCE*
+### IMPORTANT : _DO NOT SKIP THIS STEPS AND DO NOT DELETE THEM. WE CAN NOT HELP YOU IF YOU DO NOT PROVIDE INFORMATION AND STEPS TO REPRODUCE_
 
 Do not open an issue if you simply "copied" code over to your bot/another bot. This is absolutely not recommended and will cause bugs. Also do not open an issue if you modified code and added features and now it's not working right. This is because I can't figure it out and don't have the time to read your code and find out what you did wrong.
 
@@ -16,6 +15,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Use 'x' command
 2. provide 'y' argument
 
@@ -26,10 +26,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. Windows, Ubuntu...]:
- - Node.js Version(Should be v16 at least): 
- - Is python 2.7 installed?:
- - How are you hosting the bot(Locally, on a vps, heroku, glitch...):
+
+- OS: [e.g. Windows, Ubuntu...]:
+- Node.js Version(Should be v16 at least):
+- Is python 2.7 installed?:
+- How are you hosting the bot(Locally, on a vps, heroku, glitch...):
 
 **Additional context**
 Add any other context about the problem here.

--- a/packages/bot/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/packages/bot/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest/request a new bot feature
 title: ''
 labels: 'enhancement'
 assignees: ''
-
 ---
 
 **Explain your suggestion**

--- a/packages/bot/.prettierrc
+++ b/packages/bot/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "trailingComma": "none",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "arrowParens": "avoid"
-}

--- a/packages/bot/src/commands/other/reminder.ts
+++ b/packages/bot/src/commands/other/reminder.ts
@@ -1,0 +1,320 @@
+import {
+  askForDateTime,
+  checkInputs,
+  convertInputsToISO,
+  isPast,
+  saveReminder,
+  removeReminder
+} from './../../lib/utils/reminders/handleReminders';
+import { PaginatedFieldMessageEmbed } from '@sapphire/discord.js-utilities';
+import { ApplyOptions } from '@sapphire/decorators';
+import {
+  ApplicationCommandRegistry,
+  Command,
+  CommandOptions
+} from '@sapphire/framework';
+import {
+  CommandInteraction,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+  User
+} from 'discord.js';
+import { Time } from '@sapphire/time-utilities';
+import { trpcNode } from '../../trpc';
+import ReminderStore from '../../lib/utils/reminders/ReminderStore';
+
+@ApplyOptions<CommandOptions>({
+  name: 'reminder',
+  description: 'Set or View Personal Reminders',
+  preconditions: ['timeZoneExists']
+})
+export class ReminderCommand extends Command {
+  public override async chatInputRun(interaction: CommandInteraction) {
+    const subCommand = interaction.options.getSubcommand(true);
+
+    if (subCommand == 'save-timezone') {
+      return await askForDateTime(interaction);
+    }
+
+    if (subCommand == 'set') {
+      const newEvent = interaction.options.getString('event', true);
+      let timeQuery = interaction.options.getString('time', true);
+      const userDB = await trpcNode.user.getUserById.query({
+        id: interaction.user.id
+      });
+
+      if (!userDB.user || Number.isNaN(userDB?.user?.timeOffset)) {
+        await interaction.reply({
+          content:
+            ':x: Something went wrong, Please retry after using the `/reminder save-timezone` command.',
+          ephemeral: true
+        });
+        return;
+      }
+
+      const date = interaction.options.getString('date');
+      const newDescription = interaction.options.getString('description');
+      const repeat = interaction.options.getString('repeat');
+
+      if (
+        await checkInputs(
+          interaction,
+          newEvent,
+          timeQuery,
+          date!,
+          newDescription!,
+          repeat!
+        )
+      ) {
+        const isoStr = convertInputsToISO(
+          userDB.user.timeOffset!,
+          timeQuery,
+          date!
+        );
+
+        if (isPast(isoStr)) {
+          await interaction.reply({
+            content: `:x: I can't go back in time`,
+            ephemeral: true
+          });
+          return;
+        }
+        let savedToDB;
+        await interaction
+          .deferReply({
+            fetchReply: true,
+            ephemeral: true
+          })
+          .then(async () => {
+            await interaction.user
+              .send(
+                `✅ Reminder - **${newEvent}** has been set for <t:${Math.floor(
+                  new Date(isoStr).valueOf() / Time.Second
+                )}> ${repeat ? ', Repeating ' + repeat : ''}`
+              )
+              .then(async message => {
+                savedToDB = await saveReminder(interaction.user.id, {
+                  userId: interaction.user.id,
+                  timeOffset: userDB.user?.timeOffset!,
+                  event: newEvent,
+                  description: newDescription!,
+                  repeat: repeat!,
+                  dateTime: isoStr
+                });
+                if (!savedToDB) {
+                  await message.delete();
+                  await interaction.user.send({
+                    content: `❌ You already have an event named **${newEvent}**`
+                  });
+                }
+              })
+              .catch(async () => {
+                await interaction.editReply(
+                  ':x: Unable to send you a DM, reminder has been **Canceled**.'
+                );
+              });
+          });
+        if (savedToDB) {
+          await interaction.editReply('All Set');
+        } else {
+          await interaction.editReply(
+            `:x: Reminder was **not** saved${
+              interaction.channel?.type !== 'DM'
+                ? `, check your DM's for more info`
+                : ''
+            } `
+          );
+        }
+      }
+    }
+    // end of Set
+
+    if (subCommand == 'remove') {
+      const event = interaction.options.getString('event', true);
+      return await interaction.reply({
+        content: await removeReminder(interaction.user.id, event, true),
+        ephemeral: true
+      });
+    }
+
+    if (subCommand == 'view') {
+      const interactionUser = interaction.user as User;
+
+      const cache = new ReminderStore();
+      const rawKeys = await cache.getKeys(interactionUser.id);
+      const keyList: string[] = [];
+      if (!rawKeys.length) {
+        return await interaction.reply({
+          content: ":x: You don't have any reminders.",
+          ephemeral: true
+        });
+      }
+      rawKeys.forEach(key => {
+        if (!key.endsWith('trigger')) keyList.push(key);
+      });
+      const allReminders = await cache.getUsersReminders(keyList);
+      const remindersDB = allReminders.map(reminders => JSON.parse(reminders!));
+
+      const baseEmbed = new MessageEmbed()
+        .setColor('#9096e6')
+        .setAuthor({
+          name: `⏰ ${interactionUser.username} - Reminder List`
+        })
+        .setTimestamp();
+
+      const paginatedFieldTemplate = new PaginatedFieldMessageEmbed()
+        .setTitleField(`Reminders`)
+        .setTemplate(baseEmbed)
+        .setItems(remindersDB)
+        .formatItems(
+          (reminder: any) =>
+            `> **${reminder.event}** --> <t:${Math.floor(
+              new Date(reminder.dateTime).valueOf() / 1000
+            )}>`
+        )
+        .setItemsPerPage(5)
+        .make();
+
+      const embeds: any[] = [];
+      paginatedFieldTemplate.pages.forEach((value: any) =>
+        embeds.push(value.embeds)
+      ); // convert to Regular Message Embed For Ephemeral Option
+      const totalPages = paginatedFieldTemplate.pages.length;
+      if (totalPages > 1) {
+        const rowOne = new MessageActionRow().addComponents(
+          new MessageButton()
+            .setCustomId(`${interaction.id}-previous`)
+            .setEmoji('◀️')
+            .setStyle('PRIMARY'),
+          new MessageButton()
+            .setCustomId(`${interaction.id}-next`)
+            .setEmoji('▶️')
+            .setStyle('PRIMARY')
+        );
+
+        await interaction
+          .reply({
+            embeds: embeds[0],
+            ephemeral: true,
+            fetchReply: true,
+            components: [rowOne]
+          })
+          .then(() => {
+            const collector =
+              interaction.channel?.createMessageComponentCollector();
+            let currentPage = 0;
+            collector?.on('collect', button => {
+              if (interaction.user.id != button.user.id) return;
+
+              if (button.customId == `${interaction.id}-previous`) {
+                currentPage = currentPage - 1 < 0 ? 0 : currentPage - 1;
+                button.update({
+                  embeds: embeds[currentPage]
+                });
+              }
+              if (button.customId == `${interaction.id}-next`) {
+                currentPage =
+                  currentPage + 1 > totalPages ? totalPages : currentPage + 1;
+                button.update({
+                  embeds: embeds[currentPage]
+                });
+              }
+            });
+          });
+      } else {
+        await interaction.reply({
+          embeds: embeds[0],
+          ephemeral: true
+        });
+      }
+    }
+  }
+
+  public override registerApplicationCommands(
+    registry: ApplicationCommandRegistry
+  ): void {
+    registry.registerChatInputCommand({
+      name: this.name,
+      description: this.description,
+      options: [
+        {
+          type: 'SUB_COMMAND',
+          name: 'set',
+          description: 'Set a reminder.',
+          options: [
+            {
+              type: 'STRING',
+              required: true,
+              name: 'event',
+              description: 'What would you like to be reminded of?'
+            },
+            {
+              type: 'STRING',
+              required: true,
+              name: 'time',
+              description:
+                'Enter a Time for your Reminder. (ex: 14:30 for 2:30 pm)'
+            },
+            {
+              type: 'STRING',
+              required: false,
+              name: 'date',
+              description: 'Enter a Date for your reminder. (MM/DD/YYYY)'
+            },
+            {
+              type: 'STRING',
+              required: false,
+              name: 'description',
+              description: 'Enter a Description to you reminder. (Optional)'
+            },
+            {
+              type: 'STRING',
+              required: false,
+              name: 'repeat',
+              description: 'How often to repeat the reminder. (Optional)',
+              choices: [
+                {
+                  name: 'Yearly',
+                  value: 'Yearly'
+                },
+                {
+                  name: 'Monthly',
+                  value: 'Monthly'
+                },
+                {
+                  name: 'Weekly',
+                  value: 'Weekly'
+                },
+                { name: 'Daily', value: 'Daily' }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'SUB_COMMAND',
+          name: 'view',
+          description: 'Show your reminders.'
+        },
+        {
+          type: 'SUB_COMMAND',
+          name: 'remove',
+          description: 'Delete a reminder from you list.',
+          options: [
+            {
+              type: 'STRING',
+              required: true,
+              name: 'event',
+              description: 'Which reminder would you like to remove?'
+            }
+          ]
+        },
+        {
+          type: 'SUB_COMMAND',
+          name: 'save-timezone',
+          description: 'Save your timezone.'
+        }
+      ]
+    });
+  }
+}

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -10,6 +10,9 @@ import { notify } from './lib/utils/twitch/notifyChannel';
 import Logger from './lib/utils/logger';
 import { ErrorListeners } from './listeners/ErrorHandling';
 import { trpcNode } from './trpc';
+import ReminderEvents from './lib/utils/reminders/ReminderEvents';
+import { checkReminders } from './lib/utils/reminders/handleReminders';
+import { Time } from '@sapphire/time-utilities';
 
 if (process.env.SPOTIFY_CLIENT_ID && process.env.SPOTIFY_CLIENT_SECRET) {
   load({
@@ -63,6 +66,18 @@ client.on('ready', async () => {
     );
   } catch (err) {
     Logger.error('Prisma ' + err);
+  }
+
+  try {
+    ReminderEvents();
+    await checkReminders();
+
+    // maintence
+    setInterval(async () => {
+      await checkReminders();
+    }, Time.Day);
+  } catch (error) {
+    Logger.error('Reminders Start ' + error);
   }
 
   client.guilds.cache.map(async guild => {

--- a/packages/bot/src/lib/utils/reminders/ReminderEvents.ts
+++ b/packages/bot/src/lib/utils/reminders/ReminderEvents.ts
@@ -1,0 +1,87 @@
+import { container } from '@sapphire/framework';
+import { trpcNode } from '../../../trpc';
+// import { trpcNode } from '../../../trpc';
+import Logger from '../logger';
+import {
+  convertInputsToISO,
+  nextReminder,
+  ReminderI,
+  removeReminder,
+  saveReminder
+} from './handleReminders';
+import { RemindEmbed } from './reminderEmbed';
+import PubSub from './RemindersPubSub';
+import ReminderStore from './ReminderStore';
+
+const Reminders = new ReminderStore();
+
+export default function ReminderEvents() {
+  PubSub.subscribe(`__keyevent@${process.env.REDIS_DB || 0}__:expired`);
+  PubSub.on('message', async (channel: string, message: string) => {
+    const [type, user, key, value] = message.split('.');
+
+    switch (type) {
+      case 'reminders': {
+        if (value != 'trigger') return;
+        const discordUser = await container.client.users.fetch(user);
+        const cache = await Reminders.get(`reminders.${user}.${key}`);
+
+        const reminder: ReminderI | null = cache
+          ? await JSON.parse(cache)
+          : (
+              await trpcNode.reminder.getReminder.mutate({
+                userId: user,
+                event: key
+              })
+            ).reminder;
+
+        if (!reminder) return;
+
+        const remind = new RemindEmbed(
+          reminder.userId,
+          reminder.timeOffset,
+          reminder.event,
+          reminder.dateTime,
+          reminder.description!,
+          reminder.repeat!
+        );
+
+        await removeReminder(reminder.userId, reminder.event, false);
+
+        try {
+          await discordUser!.send({
+            embeds: [remind.RemindEmbed()]
+          });
+        } catch (error) {
+          Logger.info(
+            "A Reminder message failed, the intended users DM's are likely disabled."
+          );
+          Logger.debug(error);
+          return; // don't recreate entry if the users DMs is disabled
+        }
+
+        if (reminder.repeat) {
+          const nextAlarm = nextReminder(
+            reminder.timeOffset,
+            reminder.repeat,
+            reminder.dateTime
+          );
+          await saveReminder(reminder.userId, {
+            userId: reminder.userId,
+            timeOffset: reminder.timeOffset,
+            event: reminder.event,
+            dateTime: convertInputsToISO(
+              reminder.timeOffset,
+              nextAlarm.time,
+              nextAlarm.date
+            ),
+            description: reminder.description,
+            repeat: reminder.repeat
+          });
+        }
+        break;
+      } // end of Reminder Type
+    }
+    return;
+  });
+}

--- a/packages/bot/src/lib/utils/reminders/ReminderStore.ts
+++ b/packages/bot/src/lib/utils/reminders/ReminderStore.ts
@@ -1,0 +1,54 @@
+import Redis, { RedisKey, RedisValue } from 'ioredis';
+
+export default class ReminderStore {
+  redis: Redis;
+  constructor() {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number.parseInt(process.env.REDIS_PORT!) || 6379,
+      password: process.env.REDIS_PASSWORD || '',
+      db: Number.parseInt(process.env.REDIS_DB!) || 0
+    });
+    this.redis.on('ready', () => {
+      this.redis.config('SET', 'notify-keyspace-events', 'Ex');
+    });
+  }
+  get(key: RedisKey) {
+    return this.redis.get(key);
+  }
+  getKeys(key: RedisKey) {
+    return this.redis.keys(`reminders.${key}*`);
+  }
+  getUsersReminders(keys: RedisKey[]) {
+    return this.redis.mget(keys);
+  }
+  delete(key: RedisKey) {
+    return this.redis.del(key);
+  }
+  setReminder(
+    userId: string,
+    event: string,
+    value: RedisValue,
+    expire: string
+  ) {
+    event = event.replace(/\./g, '');
+    const delay = 60; // add extra time to data
+    return (
+      this.redis
+        .multi()
+        // Save a key for TTL (dummy data)
+        .set(`reminders.${userId}.${event}.trigger`, 1)
+        .expireat(
+          `reminders.${userId}.${event}.trigger`,
+          Date.parse(expire) / 1000
+        )
+        // Cache actual data
+        .set(`reminders.${userId}.${event}`, value)
+        .expireat(
+          `reminders.${userId}.${event}`,
+          Date.parse(expire) / 1000 + delay
+        )
+        .exec()
+    );
+  }
+}

--- a/packages/bot/src/lib/utils/reminders/RemindersPubSub.ts
+++ b/packages/bot/src/lib/utils/reminders/RemindersPubSub.ts
@@ -1,0 +1,24 @@
+import Redis from 'ioredis';
+
+const options = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: Number.parseInt(process.env.REDIS_PORT!) || 6379,
+  password: process.env.REDIS_PASSWORD || '',
+  db: Number.parseInt(process.env.REDIS_DB!) || 0
+};
+
+const pubSub = new Redis(options);
+
+export default new (class PubSub {
+  publish(channel: string, message: string) {
+    pubSub.publish(channel, message);
+  }
+  subscribe(channel: string) {
+    pubSub.subscribe(channel);
+  }
+  on(event: string, callback: Function) {
+    pubSub.on(event, (channel, message) => {
+      callback(channel, message);
+    });
+  }
+})();

--- a/packages/bot/src/lib/utils/reminders/handleReminders.ts
+++ b/packages/bot/src/lib/utils/reminders/handleReminders.ts
@@ -1,0 +1,407 @@
+import {
+  EmbedLimits,
+  PaginatedFieldMessageEmbed
+} from '@sapphire/discord.js-utilities';
+import {
+  CommandInteraction,
+  MessageActionRow,
+  MessageEmbed,
+  Modal,
+  ModalActionRowComponent,
+  ModalSubmitInteraction,
+  TextInputComponent
+} from 'discord.js';
+import { Time } from '@sapphire/time-utilities';
+import { trpcNode } from '../../../trpc';
+import ReminderStore from './ReminderStore';
+import Logger from '../logger';
+
+const cache = new ReminderStore();
+
+export async function saveReminder(userId: string, reminder: ReminderI) {
+  try {
+    const entry = await trpcNode.reminder.getReminder.mutate({
+      userId,
+      event: reminder.event
+    });
+    if (!entry.reminder) {
+      await trpcNode.reminder.create.mutate(reminder);
+      await cache.setReminder(
+        userId,
+        reminder.event.replace(/\./g, ''),
+        JSON.stringify(reminder),
+        reminder.dateTime
+      );
+      return true;
+    }
+  } catch (error) {
+    Logger.error('saveReminder: ', error);
+    return false;
+  }
+  return false;
+}
+
+export async function removeReminder(
+  userId: string,
+  event: string,
+  sendReply: boolean
+) {
+  const key = `reminders.${userId}.${event.replace(/\./g, '')}`;
+  const reminderExists = await cache.get(key);
+  try {
+    // Delete from Postgres
+    await trpcNode.reminder.delete.mutate({
+      userId: userId,
+      event: event
+    });
+    // Delete from cache
+    await cache.delete(`${key}.trigger`); // TTL
+    await cache.delete(key); // data
+  } catch (error) {
+    Logger.error('removeReminder: ', error);
+    if (sendReply) return ':x: Something went wrong! Please try again later.';
+  }
+
+  if (reminderExists && sendReply)
+    return `:wastebasket: Deleted reminder **${event}**.`;
+  else if (sendReply) return `:x: **${event}** was not found.`;
+
+  return ':x: Something went wrong! Please try again later.';
+}
+
+export async function checkReminders() {
+  try {
+    const DB = await trpcNode.reminder.getAll.query();
+    if (!DB.reminders || DB.reminders.length) return;
+    DB.reminders.forEach(async (reminder: any) => {
+      // Clean up Postgres incase trigger was missed
+      if (isPast(reminder.dateTime)) {
+        await removeReminder(reminder.userId, reminder.event, false);
+        return;
+      }
+      // Store the DB entry to Cache
+      await cache.setReminder(
+        reminder.userId,
+        reminder.event.replace(/\./g, ''),
+        JSON.stringify(reminder),
+        reminder.dateTime
+      );
+    });
+  } catch (error) {
+    Logger.error('checkReminders: ', error);
+    return;
+  }
+}
+
+export function convertInputsToISO(
+  userOffset: number,
+  timeQuery: string,
+  date: string
+) {
+  let isoStr: string = '';
+
+  const [hour, minute] = timeQuery.split(':');
+  timeQuery = `${padTo2Digits(hour)}:${padTo2Digits(minute)}`;
+
+  const localDateTime = new Date();
+
+  const DateEntry = date ? true : false;
+  if (!date) {
+    date = `${
+      localDateTime.getMonth() + 1
+    }/${localDateTime.getDate()}/${localDateTime.getFullYear()}`;
+  }
+  const [month, day, year] = date.split('/') || date.split('-');
+  isoStr = `${year}-${padTo2Digits(month)}-${padTo2Digits(
+    day
+  )}T${timeQuery}:00.000Z`;
+
+  const timeMS = new Date(isoStr).valueOf();
+  const userOffset2Ms = userOffset * Time.Minute;
+
+  isoStr = new Date(timeMS - userOffset2Ms).toISOString();
+
+  if (isPast(isoStr) && !DateEntry) {
+    isoStr = new Date(new Date(isoStr).valueOf() + Time.Day).toISOString();
+  }
+
+  return isoStr;
+}
+
+export function isPast(dateTime: string) {
+  return new Date(dateTime).valueOf() - Date.now() < 0 ? true : false;
+}
+
+async function findTimeZone(
+  interaction: CommandInteraction,
+  timeQuery: string,
+  date: string
+) {
+  if (await checkInputs(interaction, 'placeholder', timeQuery, date)) {
+    const [hour, minute] = timeQuery.split(':');
+
+    timeQuery = `${padTo2Digits(hour)}:${padTo2Digits(minute)}`;
+
+    const [month, day, year] = date.split('/') || date.split('-');
+    const userTime = `${year}-${padTo2Digits(month)}-${padTo2Digits(
+      day
+    )}T${timeQuery}:00.000Z`;
+
+    const userTimeMS = new Date(userTime).valueOf();
+    const rawOffset = userTimeMS - new Date().valueOf();
+    const offset = Math.round(rawOffset / Time.Minute / 5) * 5;
+
+    await trpcNode.user.updateTimeOffset.mutate({
+      id: interaction.user.id,
+      timeOffset: offset
+    });
+  }
+}
+
+export function nextReminder(
+  timeOffset: number,
+  repeat: string,
+  isoStr: string
+) {
+  const offset2MS = timeOffset * Time.Minute;
+
+  if (repeat === 'Daily') {
+    isoStr = new Date(
+      new Date(isoStr).valueOf() + Time.Day + offset2MS
+    ).toISOString();
+  }
+
+  if (repeat === 'Weekly') {
+    isoStr = new Date(
+      new Date(isoStr).valueOf() + Time.Day * 7 + offset2MS
+    ).toISOString();
+  }
+
+  isoStr = isoStr.replace(':00.000Z', '');
+  const [DBDate, DBTime] = isoStr.split('T');
+  const [DBHour, DBMinute] = DBTime.split(':');
+  const [DBYear, DBMonth, DBDay] = DBDate.split('-');
+  let year = Number.parseInt(DBYear);
+  let month = Number.parseInt(DBMonth);
+  let day = Number.parseInt(DBDay);
+  let hour = Number.parseInt(DBHour);
+  let minute = Number.parseInt(DBMinute);
+
+  if (repeat === 'Yearly') {
+    year++;
+  }
+
+  if (repeat === 'Monthly') {
+    month + 1 > 12 ? ((month = 1), year++) : month++;
+  }
+
+  return {
+    date: `${padTo2Digits(month.toString())}/${padTo2Digits(
+      day.toString()
+    )}/${year.toString()}`,
+    time: `${padTo2Digits(hour.toString())}:${padTo2Digits(
+      minute.toString()
+    )}:00.000Z`
+  };
+}
+
+export async function checkInputs(
+  interaction: CommandInteraction | ModalSubmitInteraction,
+  event: string,
+  time?: string,
+  date?: string,
+  description?: string,
+  repeat?: string
+) {
+  let Failed;
+  const errors = [];
+  let errorCount = 0;
+
+  if (time) {
+    const [hour, minute] = time.split(':');
+
+    if (
+      !Number.parseInt(hour) ||
+      padTo2Digits(hour).length > 2 ||
+      hour.indexOf(' ') >= 0
+    ) {
+      if (hour !== '00') {
+        errorCount++;
+        errors.push({
+          content: `**${errorCount}**) **Invalid Hours** - Only numbers can be used to set Hours. (Example: 13:30 for 1:30 pm)`
+        });
+        Failed = true;
+      }
+    }
+
+    if (Number.parseInt(hour) > 23 || Number.parseInt(hour) < 0) {
+      errorCount++;
+      errors.push({
+        content: `**${errorCount}**) **Invalid Hours** - Choose a number between 0 and 23. (Example: 13:30 for 1:30 pm)`
+      });
+      Failed = true;
+    }
+
+    if (
+      !Number.parseInt(minute) ||
+      padTo2Digits(minute).length > 2 ||
+      minute.indexOf(' ') >= 0
+    ) {
+      if (minute !== '00') {
+        errorCount++;
+        errors.push({
+          content: `**${errorCount}**) **Invalid Minutes** - Only numbers can be used to set Minutes. (Example: 13:30 for 1:30 pm)`
+        });
+        Failed = true;
+      }
+    }
+    if (Number.parseInt(minute) > 59 || Number.parseInt(minute) < 0) {
+      errorCount++;
+      errors.push({
+        content: `**${errorCount}**) **Invalid Minutes** - Choose a number between 0 and 59. (Example: 13:30 for 1:30 pm)`
+      });
+      Failed = true;
+    }
+  }
+
+  if (date) {
+    const [month, day, year] = date.split('/') || date.split('-');
+
+    if (
+      !Number.parseInt(month) ||
+      !Number.parseInt(day) ||
+      !Number.parseInt(year)
+    ) {
+      errorCount++;
+      errors.push({
+        content: `**${errorCount}**) **Invalid Date** - Only numbers can be used to set the Date`
+      });
+      Failed = true;
+    }
+
+    if (
+      Number.parseInt(month) > 12 ||
+      year.length !== 4 ||
+      Number.parseInt(day) > 31 ||
+      month.indexOf(' ') >= 0 ||
+      day.indexOf(' ') >= 0 ||
+      year.indexOf(' ') >= 0
+    ) {
+      errorCount++;
+      errors.push({
+        content: `**${errorCount}**) **Invalid Syntax** - Date is formatted MM/DD/YYYY`
+      });
+      Failed = true;
+    }
+
+    if (repeat) {
+      if (repeat === 'Monthly' && Number.parseInt(day) > 28) {
+        errorCount++;
+        errors.push({
+          content: `**${errorCount}**) **Invalid Setting Combo** - Day cannot be after the 28th with "Monthly" Repeat setting enabled. (Blame February <3)`
+        });
+        Failed = true;
+      }
+    }
+  }
+  if (event.length > EmbedLimits.MaximumTitleLength) {
+    errorCount++;
+    errors.push({
+      content: `**${errorCount}**) **Limitation** - Event titles have a maximum length of ${EmbedLimits.MaximumTitleLength} characters`
+    });
+
+    Failed = true;
+  }
+  if (description) {
+    if (description.length > EmbedLimits.MaximumDescriptionLength) {
+      errorCount++;
+      errors.push({
+        content: `**${errorCount}**) **Limitation** - Descriptions have a maximum length of ${EmbedLimits.MaximumDescriptionLength} characters`
+      });
+      Failed = true;
+    }
+  }
+  if (Failed) {
+    const errorEmbed = new MessageEmbed()
+      .setColor('BLURPLE')
+      .setAuthor({
+        name: `Reminder - Error Message`,
+        iconURL: interaction.user.displayAvatarURL()
+      })
+      .setDescription(`**There was an error processing your request!**`);
+    const paginatedFieldTemplate = new PaginatedFieldMessageEmbed()
+      .setTitleField(`:x: Issues`)
+      .setTemplate(errorEmbed)
+      .setItems(errors)
+      .formatItems((item: any) => `> ${item.content}`)
+      .setItemsPerPage(10)
+      .make();
+    const embeds = paginatedFieldTemplate.pages.values().next().value.embeds; // convert to Regular Message Embed For Ephemeral Option
+    await interaction.reply({ embeds: embeds, ephemeral: true });
+  }
+  // inputs Passed the Error check
+  return true;
+}
+
+export async function askForDateTime(interaction: CommandInteraction) {
+  const modal = new Modal()
+    .setCustomId('Reminder-TimeZone' + interaction.id)
+    .setTitle('Reminder - Save Time Zone');
+  const time = new TextInputComponent()
+    .setCustomId('time' + interaction.id)
+    .setLabel(`Enter your Current Time Ex. "14:30"`)
+    .setPlaceholder('14:30')
+    .setStyle('SHORT')
+    .setRequired(true);
+  const date = new TextInputComponent()
+    .setCustomId('date' + interaction.id)
+    .setLabel(`Enter your Current Date Ex. "MM/DD/YYYY"`)
+    .setPlaceholder('12/23/2022')
+    .setStyle('SHORT')
+    .setRequired(true);
+  const rowOne = new MessageActionRow<ModalActionRowComponent>().addComponents(
+    date
+  );
+  const rowTwo = new MessageActionRow<ModalActionRowComponent>().addComponents(
+    time
+  );
+
+  modal.addComponents(rowOne, rowTwo);
+  await interaction.showModal(modal);
+
+  const filter = (response: ModalSubmitInteraction) => {
+    return response.isModalSubmit();
+  };
+  const submission = await interaction.awaitModalSubmit({
+    filter,
+    time: 5 * Time.Minute
+  });
+
+  const dateInput = submission.fields.getTextInputValue(
+    'date' + interaction.id
+  );
+  const timeInput = submission.fields.getTextInputValue(
+    'time' + interaction.id
+  );
+  if (await checkInputs(submission, 'placeholder', timeInput, dateInput)) {
+    await findTimeZone(interaction, timeInput, dateInput);
+
+    await submission.reply({
+      content: 'Your Time Zone Offset has been saved.',
+      ephemeral: true
+    });
+  }
+}
+
+function padTo2Digits(num: string) {
+  return num.toString().padStart(2, '0');
+}
+
+export interface ReminderI {
+  userId: string;
+  timeOffset: number;
+  event: string;
+  description: string | null;
+  dateTime: string;
+  repeat: string | null;
+}

--- a/packages/bot/src/lib/utils/reminders/reminderEmbed.ts
+++ b/packages/bot/src/lib/utils/reminders/reminderEmbed.ts
@@ -1,0 +1,72 @@
+import { container } from '@sapphire/framework';
+import { MessageEmbed } from 'discord.js';
+import { convertInputsToISO, nextReminder } from './handleReminders';
+
+export class RemindEmbed {
+  userId: string;
+  timeOffset: number;
+  event: string;
+  dateTime: string;
+  description?: string;
+  repeat?: string;
+
+  public constructor(
+    userId: string,
+    timeOffset: number,
+    event: string,
+    dateTime: string,
+    description?: string,
+    repeat?: string
+  ) {
+    this.userId = userId;
+    this.timeOffset = timeOffset;
+    this.event = event;
+    this.dateTime = dateTime;
+    this.description = description;
+    this.repeat = repeat;
+  }
+  public RemindEmbed() {
+    const { client } = container;
+    const user = client.users.cache.get(this.userId);
+    const baseEmbed = new MessageEmbed()
+      .setColor('YELLOW')
+      .setTitle(
+        `⏰ Reminder - ${
+          this.event.charAt(0).toUpperCase() + this.event.slice(1).toLowerCase()
+        }`
+      )
+      .setFooter({
+        iconURL: user?.displayAvatarURL(),
+        text: user?.username!
+      })
+      .setTimestamp();
+
+    if (this.repeat) {
+      const nextAlarm = nextReminder(
+        this.timeOffset,
+        this.repeat!,
+        this.dateTime
+      );
+      baseEmbed.addFields([
+        {
+          name: 'Next Alarm',
+          value: `> <t:${Math.floor(
+            new Date(
+              convertInputsToISO(
+                this.timeOffset,
+                nextAlarm.time,
+                nextAlarm.date
+              )
+            ).valueOf() / 1000
+          )}>`,
+          inline: true
+        },
+        { name: 'Repeated', value: `> ${this.repeat}`, inline: true }
+      ]);
+    }
+    if (this.description)
+      if (this.description.length > 0)
+        baseEmbed.setDescription(`> ${this.description}`);
+    return baseEmbed;
+  }
+}

--- a/packages/bot/src/preconditions/timeZoneExists.ts
+++ b/packages/bot/src/preconditions/timeZoneExists.ts
@@ -1,0 +1,55 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import {
+  AsyncPreconditionResult,
+  Precondition,
+  PreconditionOptions
+} from '@sapphire/framework';
+import type { CommandInteraction, User } from 'discord.js';
+import Logger from '../lib/utils/logger';
+import { trpcNode } from '../trpc';
+
+@ApplyOptions<PreconditionOptions>({
+  name: 'timeZoneExists'
+})
+export class TimeZoneExists extends Precondition {
+  public override async chatInputRun(
+    interaction: CommandInteraction
+  ): AsyncPreconditionResult {
+    const discordUser = interaction.user as User;
+
+    try {
+      const user = await trpcNode.user.create.mutate({
+        id: discordUser.id,
+        name: discordUser.username
+      });
+
+      if (!user) throw new Error();
+    } catch (error) {
+      Logger.error(error);
+      return this.error({ message: 'Something went wrong!' });
+    }
+
+    const subCommand = interaction.options.getSubcommand(true);
+
+    if (subCommand == 'set') {
+      const discordUser = interaction.user as User;
+
+      const user = await trpcNode.user.getUserById.query({
+        id: discordUser.id
+      });
+
+      return Number.isInteger(user.user?.timeOffset)
+        ? this.ok()
+        : this.error({
+            message: `You have no Time Zone saved\n Please the use \`/reminder save-timezone\` first.`
+          });
+    }
+    return this.ok(); // ok its not the Set Sub_Command
+  }
+}
+
+declare module '@sapphire/framework' {
+  export interface Preconditions {
+    timeZoneExists: never;
+  }
+}

--- a/packages/dashboard/next.config.mjs
+++ b/packages/dashboard/next.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
-import transpile from "next-transpile-modules";
-import { env } from "./src/env/server.mjs";
+import transpile from 'next-transpile-modules';
+import { env } from './src/env/server.mjs';
 /**
  * Don't be scared of the generics here.
  * All they do is to give us autocompletion when using this.
@@ -13,14 +13,14 @@ function defineNextConfig(config) {
   return config;
 }
 
-const withTM = transpile(["@master-bot/api", "@master-bot/react"]);
+const withTM = transpile(['@master-bot/api', '@master-bot/react']);
 
 export default withTM(
   defineNextConfig({
     reactStrictMode: true,
     swcMinify: true,
     experimental: {
-      externalDir: true,
-    },
+      externalDir: true
+    }
   })
 );

--- a/packages/dashboard/postcss.config.cjs
+++ b/packages/dashboard/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
+    autoprefixer: {}
+  }
 };

--- a/packages/dashboard/src/components/CommandInfo/CommandInfo.tsx
+++ b/packages/dashboard/src/components/CommandInfo/CommandInfo.tsx
@@ -1,13 +1,13 @@
-import { Switch } from "@headlessui/react";
-import React from "react";
-import { trpc } from "../../utils/trpc";
+import { Switch } from '@headlessui/react';
+import React from 'react';
+import { trpc } from '../../utils/trpc';
 
 const CommandInfo = ({
   name,
   description,
   guildId,
   commandId,
-  disabled,
+  disabled
 }: {
   name: string;
   description: string;
@@ -24,7 +24,7 @@ const CommandInfo = ({
       {
         guildId,
         commandId,
-        status,
+        status
       },
       {
         onSuccess: () => {
@@ -37,7 +37,7 @@ const CommandInfo = ({
         },
         onSettled: () => {
           setDisableSwitch(false);
-        },
+        }
       }
     );
   }
@@ -45,13 +45,13 @@ const CommandInfo = ({
   return (
     <div
       className={`p-5 flex justify-between items-center transition duration-200 ease-in-out ${
-        disabled ? "bg-gray-700" : "bg-black"
+        disabled ? 'bg-gray-700' : 'bg-black'
       }`}
     >
       <div className="flex flex-col gap-2">
         <h2
           className={`transition duration-200 ease-in-out ${
-            disabled ? "text-slate-400" : "text-white"
+            disabled ? 'text-slate-400' : 'text-white'
           }`}
         >
           {name}
@@ -67,15 +67,15 @@ const CommandInfo = ({
             handleToggle(!disabled);
           }}
           className={`${
-            disabled ? "bg-gray-400" : "bg-blue-600"
+            disabled ? 'bg-gray-400' : 'bg-blue-600'
           } relative inline-flex h-6 w-11 items-center rounded-full`}
         >
-          {" "}
+          {' '}
           <span className="sr-only">Enable or disable command</span>
           <span
             aria-hidden="true"
             className={`${
-              disabled ? "translate-x-1" : "translate-x-6"
+              disabled ? 'translate-x-1' : 'translate-x-6'
             } inline-block h-4 w-4 transform rounded-full bg-white transition duration-200 ease-in-out`}
           />
         </Switch>

--- a/packages/dashboard/src/components/CommandInfo/index.ts
+++ b/packages/dashboard/src/components/CommandInfo/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./CommandInfo";
-export * from "./CommandInfo";
+export { default } from './CommandInfo';
+export * from './CommandInfo';

--- a/packages/dashboard/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/packages/dashboard/src/components/DashboardLayout/DashboardLayout.tsx
@@ -1,21 +1,21 @@
-import React from "react";
-import Logo from "../Logo";
-import Link from "next/link";
-import { trpc } from "../../utils/trpc";
-import { useRouter } from "next/router";
-import Head from "next/head";
+import React from 'react';
+import Logo from '../Logo';
+import Link from 'next/link';
+import { trpc } from '../../utils/trpc';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
 
 const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
   const router = useRouter();
   const query = router.query.guild_id;
 
-  if (!query || typeof query !== "string") {
-    router.push("/");
+  if (!query || typeof query !== 'string') {
+    router.push('/');
   }
 
   const { data, isLoading } = trpc.guild.getGuild.useQuery({
-    id: query as string,
+    id: query as string
   });
 
   return (
@@ -31,7 +31,7 @@ const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
             </div>
             <div className="bg-black text-center text-white font-semibold py-2 mb-12 rounded-xl">
               <p>
-                {isLoading && !data ? "Loading Guild..." : data!.guild!.name}
+                {isLoading && !data ? 'Loading Guild...' : data!.guild!.name}
               </p>
             </div>
             <div className="flex flex-col gap-8">

--- a/packages/dashboard/src/components/DashboardLayout/index.ts
+++ b/packages/dashboard/src/components/DashboardLayout/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./DashboardLayout";
-export * from "./DashboardLayout";
+export { default } from './DashboardLayout';
+export * from './DashboardLayout';

--- a/packages/dashboard/src/components/GuildSelectBox/GuildSelectBox.tsx
+++ b/packages/dashboard/src/components/GuildSelectBox/GuildSelectBox.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import { env } from "../../env/client.mjs";
+import Link from 'next/link';
+import { env } from '../../env/client.mjs';
 
 interface GuildSelectBoxProps {
   img: string;
@@ -19,7 +19,7 @@ const GuildSelectBox = ({ img, name, isBotIn, id }: GuildSelectBoxProps) => {
         {isBotIn ? (
           <Link href={`/dashboard/${id}`}>
             <button className="px-7 py-3 bg-blue-900 rounded-md hover:bg-blue-700">
-              {isBotIn ? "Go" : "Invite"}
+              {isBotIn ? 'Go' : 'Invite'}
             </button>
           </Link>
         ) : (

--- a/packages/dashboard/src/components/GuildSelectBox/index.ts
+++ b/packages/dashboard/src/components/GuildSelectBox/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./GuildSelectBox";
-export * from "./GuildSelectBox";
+export { default } from './GuildSelectBox';
+export * from './GuildSelectBox';

--- a/packages/dashboard/src/components/HeaderButton/HeaderButton.tsx
+++ b/packages/dashboard/src/components/HeaderButton/HeaderButton.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import React from "react";
+import Link from 'next/link';
+import React from 'react';
 
 interface HeaderButtonProps {
   children: React.ReactNode;
@@ -12,23 +12,23 @@ const HeaderButton = ({
   children,
   linkTo,
   newWindow,
-  external,
+  external
 }: HeaderButtonProps) => {
   const linkStyles =
-    "p-3 text-white bg-purple-600 rounded font-light hover:bg-purple-500";
+    'p-3 text-white bg-purple-600 rounded font-light hover:bg-purple-500';
   return (
     <div>
       {external ? (
         <a
           href={linkTo}
           className={linkStyles}
-          target={newWindow ? "_blank" : ""}
+          target={newWindow ? '_blank' : ''}
           rel="noreferrer"
         >
           {children}
         </a>
       ) : (
-        <Link href={linkTo} target={newWindow ? "_blank" : ""}>
+        <Link href={linkTo} target={newWindow ? '_blank' : ''}>
           <a className={linkStyles}>{children}</a>
         </Link>
       )}

--- a/packages/dashboard/src/components/HeaderButton/index.ts
+++ b/packages/dashboard/src/components/HeaderButton/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./HeaderButton";
-export * from "./HeaderButton";
+export { default } from './HeaderButton';
+export * from './HeaderButton';

--- a/packages/dashboard/src/components/Logo/index.ts
+++ b/packages/dashboard/src/components/Logo/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./Logo";
-export * from "./Logo";
+export { default } from './Logo';
+export * from './Logo';

--- a/packages/dashboard/src/components/WelcomeMessageChannelPicker/WelcomeMessageChannelPicker.tsx
+++ b/packages/dashboard/src/components/WelcomeMessageChannelPicker/WelcomeMessageChannelPicker.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { trpc } from "../../utils/trpc";
+import React from 'react';
+import { trpc } from '../../utils/trpc';
 
 const WelcomeMessageChannelPicker = ({ guildId }: { guildId: string }) => {
   const { data: channelData, isLoading: isLoadingChannelData } =
     trpc.welcome.getChannel.useQuery({
-      guildId,
+      guildId
     });
 
   const [value, setValue] = React.useState(
@@ -12,7 +12,7 @@ const WelcomeMessageChannelPicker = ({ guildId }: { guildId: string }) => {
   );
 
   const { data, isLoading } = trpc.channel.getAll.useQuery({
-    guildId,
+    guildId
   });
 
   const { mutate } = trpc.welcome.setChannel.useMutation();
@@ -26,10 +26,10 @@ const WelcomeMessageChannelPicker = ({ guildId }: { guildId: string }) => {
         <div className="flex flex-col gap-3">
           <select
             className="w-56 h-7 outline-none text-black bg-white rounded-sm hover:text-white hover:bg-black hover:cursor-pointer hover:border hover:border-white"
-            value={value ? value : ""}
-            onChange={(e) => setValue(e.target.value)}
+            value={value ? value : ''}
+            onChange={e => setValue(e.target.value)}
           >
-            {data?.channels.map((channel) => (
+            {data?.channels.map(channel => (
               <option value={channel.id} key={channel.id}>
                 {channel.name}
               </option>
@@ -42,7 +42,7 @@ const WelcomeMessageChannelPicker = ({ guildId }: { guildId: string }) => {
               if (!value) return;
               mutate({
                 guildId,
-                channelId: value,
+                channelId: value
               });
             }}
           >

--- a/packages/dashboard/src/components/WelcomeMessageChannelPicker/index.ts
+++ b/packages/dashboard/src/components/WelcomeMessageChannelPicker/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./WelcomeMessageChannelPicker";
-export * from "./WelcomeMessageChannelPicker";
+export { default } from './WelcomeMessageChannelPicker';
+export * from './WelcomeMessageChannelPicker';

--- a/packages/dashboard/src/components/WelcomeMessageInput/WelcomeMessageInput.tsx
+++ b/packages/dashboard/src/components/WelcomeMessageInput/WelcomeMessageInput.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { trpc } from "../../utils/trpc";
+import React from 'react';
+import { trpc } from '../../utils/trpc';
 
 const WelcomeMessageInput = ({ guildId }: { guildId: string }) => {
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = React.useState('');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const { mutate } = trpc.welcome.setMessage.useMutation();
@@ -13,7 +13,7 @@ const WelcomeMessageInput = ({ guildId }: { guildId: string }) => {
     mutate(
       {
         guildId,
-        message,
+        message
       },
       {
         onSuccess: () => {
@@ -21,7 +21,7 @@ const WelcomeMessageInput = ({ guildId }: { guildId: string }) => {
         },
         onError: () => {
           setIsSubmitting(false);
-        },
+        }
       }
     );
   }
@@ -32,8 +32,8 @@ const WelcomeMessageInput = ({ guildId }: { guildId: string }) => {
         name="welcome_message"
         placeholder="welcome message input"
         value={message}
-        defaultValue={data?.message ? data.message : "Loading..."}
-        onChange={(e) => setMessage(e.target.value)}
+        defaultValue={data?.message ? data.message : 'Loading...'}
+        onChange={e => setMessage(e.target.value)}
         className="block -ml-1 w-full bg-black outline-none overflow-auto my-2 resize-none p-4 text-white rounded-lg border border-gray-800 focus:ring-blue-600 focus:border-blue-600"
       />
       <button
@@ -41,7 +41,7 @@ const WelcomeMessageInput = ({ guildId }: { guildId: string }) => {
         type="submit"
         onClick={handleSubmit}
       >
-        {isSubmitting ? "Submitting..." : "Submit"}
+        {isSubmitting ? 'Submitting...' : 'Submit'}
       </button>
     </div>
   );

--- a/packages/dashboard/src/components/WelcomeMessageInput/index.ts
+++ b/packages/dashboard/src/components/WelcomeMessageInput/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./WelcomeMessageInput";
-export * from "./WelcomeMessageInput";
+export { default } from './WelcomeMessageInput';
+export * from './WelcomeMessageInput';

--- a/packages/dashboard/src/env/client.mjs
+++ b/packages/dashboard/src/env/client.mjs
@@ -1,32 +1,32 @@
 // @ts-check
-import { clientEnv, clientSchema } from "./schema.mjs";
+import { clientEnv, clientSchema } from './schema.mjs';
 
 const _clientEnv = clientSchema.safeParse(clientEnv);
 
 export const formatErrors = (
   /** @type {import('zod').ZodFormattedError<Map<string,string>,string>} */
-  errors,
+  errors
 ) =>
   Object.entries(errors)
     .map(([name, value]) => {
-      if (value && "_errors" in value)
-        return `${name}: ${value._errors.join(", ")}\n`;
+      if (value && '_errors' in value)
+        return `${name}: ${value._errors.join(', ')}\n`;
     })
     .filter(Boolean);
 
 if (!_clientEnv.success) {
   console.error(
-    "❌ Invalid environment variables:\n",
-    ...formatErrors(_clientEnv.error.format()),
+    '❌ Invalid environment variables:\n',
+    ...formatErrors(_clientEnv.error.format())
   );
-  throw new Error("Invalid environment variables");
+  throw new Error('Invalid environment variables');
 }
 
 for (let key of Object.keys(_clientEnv.data)) {
-  if (!key.startsWith("NEXT_PUBLIC_")) {
-    console.warn("❌ Invalid public environment variable name:", key);
+  if (!key.startsWith('NEXT_PUBLIC_')) {
+    console.warn('❌ Invalid public environment variable name:', key);
 
-    throw new Error("Invalid public environment variable name");
+    throw new Error('Invalid public environment variable name');
   }
 }
 

--- a/packages/dashboard/src/env/schema.mjs
+++ b/packages/dashboard/src/env/schema.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { z } from "zod";
+import { z } from 'zod';
 
 /**
  * Specify your server-side environment variables schema here.
@@ -8,9 +8,9 @@ import { z } from "zod";
 export const serverSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
-  NEXTAUTH_URL_INTERNAL: z.string().url().default("http://localhost:3000"),
+  NEXTAUTH_URL_INTERNAL: z.string().url().default('http://localhost:3000'),
   DISCORD_CLIENT_ID: z.string(),
-  DISCORD_CLIENT_SECRET: z.string(),
+  DISCORD_CLIENT_SECRET: z.string()
 });
 
 /**
@@ -19,7 +19,7 @@ export const serverSchema = z.object({
  * To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 export const clientSchema = z.object({
-  NEXT_PUBLIC_INVITE_URL: z.string().url(),
+  NEXT_PUBLIC_INVITE_URL: z.string().url()
 });
 
 /**
@@ -29,5 +29,5 @@ export const clientSchema = z.object({
  * @type {{ [k in keyof z.infer<typeof clientSchema>]: z.infer<typeof clientSchema>[k] | undefined }}
  */
 export const clientEnv = {
-  NEXT_PUBLIC_INVITE_URL: process.env.NEXT_PUBLIC_INVITE_URL,
+  NEXT_PUBLIC_INVITE_URL: process.env.NEXT_PUBLIC_INVITE_URL
 };

--- a/packages/dashboard/src/env/server.mjs
+++ b/packages/dashboard/src/env/server.mjs
@@ -3,24 +3,24 @@
  * This file is included in `/next.config.mjs` which ensures the app isn't built with invalid env vars.
  * It has to be a `.mjs`-file to be imported there.
  */
-import { serverSchema } from "./schema.mjs";
-import { env as clientEnv, formatErrors } from "./client.mjs";
+import { serverSchema } from './schema.mjs';
+import { env as clientEnv, formatErrors } from './client.mjs';
 
 const _serverEnv = serverSchema.safeParse(process.env);
 
 if (!_serverEnv.success) {
   console.error(
-    "❌ Invalid environment variables:\n",
-    ...formatErrors(_serverEnv.error.format()),
+    '❌ Invalid environment variables:\n',
+    ...formatErrors(_serverEnv.error.format())
   );
-  throw new Error("Invalid environment variables");
+  throw new Error('Invalid environment variables');
 }
 
 for (let key of Object.keys(_serverEnv.data)) {
-  if (key.startsWith("NEXT_PUBLIC_")) {
-    console.warn("❌ You are exposing a server-side env-variable:", key);
+  if (key.startsWith('NEXT_PUBLIC_')) {
+    console.warn('❌ You are exposing a server-side env-variable:', key);
 
-    throw new Error("You are exposing a server-side env-variable");
+    throw new Error('You are exposing a server-side env-variable');
   }
 }
 

--- a/packages/dashboard/src/pages/_app.tsx
+++ b/packages/dashboard/src/pages/_app.tsx
@@ -1,11 +1,11 @@
-import "../styles/globals.css";
-import { trpc } from "../utils/trpc";
-import { SessionProvider } from "next-auth/react";
-import type { NextPage } from "next";
-import type { ReactElement, ReactNode } from "react";
-import type { AppProps } from "next/app";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import '../styles/globals.css';
+import { trpc } from '../utils/trpc';
+import { SessionProvider } from 'next-auth/react';
+import type { NextPage } from 'next';
+import type { ReactElement, ReactNode } from 'react';
+import type { AppProps } from 'next/app';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 export type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -16,12 +16,12 @@ type AppPropsWithLayout = AppProps & {
 };
 
 const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
-  const getLayout = Component.getLayout ?? ((page) => page);
+  const getLayout = Component.getLayout ?? (page => page);
 
   return (
     <SessionProvider session={pageProps.session}>
       <div className="bg-slate-800 h-screen">
-        <ToastContainer theme={"dark"} toastClassName="p-4" />
+        <ToastContainer theme={'dark'} toastClassName="p-4" />
         {getLayout(<Component {...pageProps} />)}
       </div>
     </SessionProvider>

--- a/packages/dashboard/src/pages/api/auth/[...nextauth].ts
+++ b/packages/dashboard/src/pages/api/auth/[...nextauth].ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
-import NextAuth, { type NextAuthOptions } from "next-auth";
-import DiscordProvider, { DiscordProfile } from "next-auth/providers/discord";
+import NextAuth, { type NextAuthOptions } from 'next-auth';
+import DiscordProvider, { DiscordProfile } from 'next-auth/providers/discord';
 
 // Prisma adapter for NextAuth
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { prisma } from "@master-bot/api/src/db/client";
-import { env } from "../../../env/server.mjs";
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { prisma } from '@master-bot/api/src/db/client';
+import { env } from '../../../env/server.mjs';
 
 export const authOptions: NextAuthOptions = {
   // Include user.id on session
@@ -16,7 +16,7 @@ export const authOptions: NextAuthOptions = {
         session.user.discordId = user.discordId;
       }
       return session;
-    },
+    }
   },
   // Configure one or more authentication providers
   adapter: PrismaAdapter(prisma),
@@ -24,23 +24,23 @@ export const authOptions: NextAuthOptions = {
     DiscordProvider({
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
-      authorization: { params: { scope: "identify guilds" } },
+      authorization: { params: { scope: 'identify guilds' } },
       profile(profile: DiscordProfile) {
         return {
           id: profile.id,
           name: profile.username,
           email: profile.email,
           image: profile.avatar,
-          discordId: profile.id,
+          discordId: profile.id
         };
-      },
-    }),
+      }
+    })
     // ...add more providers here
   ],
   pages: {
-    signin: "/auth/signin",
-    signout: "/auth/signout",
-  },
+    signin: '/auth/signin',
+    signout: '/auth/signout'
+  }
 };
 
 export default NextAuth(authOptions);

--- a/packages/dashboard/src/pages/api/restricted.ts
+++ b/packages/dashboard/src/pages/api/restricted.ts
@@ -1,8 +1,8 @@
 // Example of a restricted endpoint that only authenticated users can access from https://next-auth.js.org/getting-started/example
 
-import { NextApiRequest, NextApiResponse } from "next";
-import { unstable_getServerSession as getServerSession } from "next-auth";
-import { authOptions as nextAuthOptions } from "./auth/[...nextauth]";
+import { NextApiRequest, NextApiResponse } from 'next';
+import { unstable_getServerSession as getServerSession } from 'next-auth';
+import { authOptions as nextAuthOptions } from './auth/[...nextauth]';
 
 const restricted = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getServerSession(req, res, nextAuthOptions);
@@ -10,12 +10,11 @@ const restricted = async (req: NextApiRequest, res: NextApiResponse) => {
   if (session) {
     res.send({
       content:
-        "This is protected content. You can access this content because you are signed in.",
+        'This is protected content. You can access this content because you are signed in.'
     });
   } else {
     res.send({
-      error:
-        "You must be signed in to view the protected content on this page.",
+      error: 'You must be signed in to view the protected content on this page.'
     });
   }
 };

--- a/packages/dashboard/src/pages/api/trpc/[trpc].ts
+++ b/packages/dashboard/src/pages/api/trpc/[trpc].ts
@@ -1,12 +1,12 @@
 /**
  * This file contains tRPC's HTTP response handler
  */
-import { createNextApiHandler } from "@trpc/server/adapters/next";
-import { appRouter } from "@master-bot/api/src/routers/index";
-import { createContext } from "@master-bot/api/src/createContext";
+import { createNextApiHandler } from '@trpc/server/adapters/next';
+import { appRouter } from '@master-bot/api/src/routers/index';
+import { createContext } from '@master-bot/api/src/createContext';
 
 // export API handler
 export default createNextApiHandler({
   router: appRouter,
-  createContext,
+  createContext
 });

--- a/packages/dashboard/src/pages/dashboard/[guild_id]/commands.tsx
+++ b/packages/dashboard/src/pages/dashboard/[guild_id]/commands.tsx
@@ -1,17 +1,17 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { useRouter } from "next/router";
-import type { ReactElement } from "react";
-import CommandInfo from "../../../components/CommandInfo";
-import DashboardLayout from "../../../components/DashboardLayout";
-import { getServerSession } from "../../../shared/get-server-session";
-import { trpc } from "../../../utils/trpc";
-import { NextPageWithLayout } from "../../_app";
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { useRouter } from 'next/router';
+import type { ReactElement } from 'react';
+import CommandInfo from '../../../components/CommandInfo';
+import DashboardLayout from '../../../components/DashboardLayout';
+import { getServerSession } from '../../../shared/get-server-session';
+import { trpc } from '../../../utils/trpc';
+import { NextPageWithLayout } from '../../_app';
 
 const CommandsDashboardPage: NextPageWithLayout = () => {
   const router = useRouter();
   const query = router.query.guild_id;
-  if (!query || typeof query !== "string") {
-    router.push("/");
+  if (!query || typeof query !== 'string') {
+    router.push('/');
   }
 
   const { isLoading, error } = trpc.guild.getGuildAndUser.useQuery(
@@ -23,7 +23,7 @@ const CommandsDashboardPage: NextPageWithLayout = () => {
     return <div>Loading...</div>;
   }
 
-  if (error?.data?.code === "UNAUTHORIZED") {
+  if (error?.data?.code === 'UNAUTHORIZED') {
     return <div>{error.message}</div>;
   }
 
@@ -31,12 +31,12 @@ const CommandsDashboardPage: NextPageWithLayout = () => {
 };
 
 const CommandsDashboardPageComponent = ({
-  query,
+  query
 }: {
   query: string;
 }): ReactElement => {
   const { data, isLoading } = trpc.command.getCommands.useQuery({
-    guildId: query as string,
+    guildId: query as string
   });
 
   const { data: disabledCommandsData, isLoading: disabledCommandsLoading } =
@@ -52,7 +52,7 @@ const CommandsDashboardPageComponent = ({
       disabledCommandsData?.disabledCommands &&
       !disabledCommandsLoading ? (
         <div className="p-5 bg-gray-900 text-slate-300 flex flex-col gap-7">
-          {data.commands.map((command) => (
+          {data.commands.map(command => (
             <CommandInfo
               key={command.id}
               guildId={query as string}
@@ -83,15 +83,15 @@ export const getServerSideProps: GetServerSideProps = async (
 
   if (!session || !session.user || !session.user.id) {
     return {
-      redirect: { destination: "../../api/auth/signin", permanent: false },
-      props: {},
+      redirect: { destination: '../../api/auth/signin', permanent: false },
+      props: {}
     };
   }
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/pages/dashboard/[guild_id]/index.tsx
+++ b/packages/dashboard/src/pages/dashboard/[guild_id]/index.tsx
@@ -1,16 +1,16 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { useRouter } from "next/router";
-import { ReactElement } from "react";
-import DashboardLayout from "../../../components/DashboardLayout";
-import { getServerSession } from "../../../shared/get-server-session";
-import { trpc } from "../../../utils/trpc";
-import { NextPageWithLayout } from "../../_app";
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
+import DashboardLayout from '../../../components/DashboardLayout';
+import { getServerSession } from '../../../shared/get-server-session';
+import { trpc } from '../../../utils/trpc';
+import { NextPageWithLayout } from '../../_app';
 
 const GuildIndexPage: NextPageWithLayout = () => {
   const router = useRouter();
   const query = router.query.guild_id;
-  if (!query || typeof query !== "string") {
-    router.push("/");
+  if (!query || typeof query !== 'string') {
+    router.push('/');
   }
 
   const { isLoading, error } = trpc.guild.getGuildAndUser.useQuery(
@@ -22,7 +22,7 @@ const GuildIndexPage: NextPageWithLayout = () => {
     return <div>Loading...</div>;
   }
 
-  if (error?.data?.code === "UNAUTHORIZED") {
+  if (error?.data?.code === 'UNAUTHORIZED') {
     return <div>{error.message}</div>;
   }
 
@@ -44,15 +44,15 @@ export const getServerSideProps: GetServerSideProps = async (
 
   if (!session || !session.user || !session.user.id) {
     return {
-      redirect: { destination: "../../api/auth/signin", permanent: false },
-      props: {},
+      redirect: { destination: '../../api/auth/signin', permanent: false },
+      props: {}
     };
   }
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/pages/dashboard/[guild_id]/temporary_channels.tsx
+++ b/packages/dashboard/src/pages/dashboard/[guild_id]/temporary_channels.tsx
@@ -1,19 +1,19 @@
-import React from "react";
-import { useRouter } from "next/router";
-import { ReactElement } from "react";
-import DashboardLayout from "../../../components/DashboardLayout";
-import { trpc } from "../../../utils/trpc";
-import { NextPageWithLayout } from "../../_app";
-import { toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { getServerSession } from "../../../shared/get-server-session";
+import React from 'react';
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
+import DashboardLayout from '../../../components/DashboardLayout';
+import { trpc } from '../../../utils/trpc';
+import { NextPageWithLayout } from '../../_app';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { getServerSession } from '../../../shared/get-server-session';
 
 const TemporaryChannelsDashboardPage: NextPageWithLayout = () => {
   const router = useRouter();
   const query = router.query.guild_id;
-  if (!query || typeof query !== "string") {
-    router.push("/");
+  if (!query || typeof query !== 'string') {
+    router.push('/');
   }
 
   const { isLoading, error } = trpc.guild.getGuildAndUser.useQuery(
@@ -25,7 +25,7 @@ const TemporaryChannelsDashboardPage: NextPageWithLayout = () => {
     return <div>Loading...</div>;
   }
 
-  if (error?.data?.code === "UNAUTHORIZED") {
+  if (error?.data?.code === 'UNAUTHORIZED') {
     return <div>{error.message}</div>;
   }
 
@@ -33,7 +33,7 @@ const TemporaryChannelsDashboardPage: NextPageWithLayout = () => {
 };
 
 const TemporaryChannelsDashboardPageComponent = ({
-  query,
+  query
 }: {
   query: string;
 }) => {
@@ -47,60 +47,60 @@ const TemporaryChannelsDashboardPageComponent = ({
         {
           onSuccess: () => {
             setIsToggling(false);
-            toast.success("Temporary channels disabled", {
-              position: "top-right",
+            toast.success('Temporary channels disabled', {
+              position: 'top-right',
               autoClose: 5000,
               hideProgressBar: false,
               closeOnClick: true,
               pauseOnHover: false,
               draggable: true,
-              progress: undefined,
+              progress: undefined
             });
             utils.guild.getGuild.invalidate();
           },
           onError: () => {
             setIsToggling(false);
-            toast.error("Error!", {
-              position: "top-right",
+            toast.error('Error!', {
+              position: 'top-right',
               autoClose: 5000,
               hideProgressBar: false,
               closeOnClick: true,
               pauseOnHover: false,
               draggable: true,
-              progress: undefined,
+              progress: undefined
             });
-          },
+          }
         }
       );
     } else {
       createHub(
-        { guildId: query as string, name: "Join To Create" },
+        { guildId: query as string, name: 'Join To Create' },
         {
           onSuccess: () => {
             setIsToggling(false);
-            toast.success("Temporary channels enabled", {
-              position: "top-right",
+            toast.success('Temporary channels enabled', {
+              position: 'top-right',
               autoClose: 5000,
               hideProgressBar: false,
               closeOnClick: true,
               pauseOnHover: false,
               draggable: true,
-              progress: undefined,
+              progress: undefined
             });
             utils.guild.getGuild.invalidate();
           },
           onError: () => {
             setIsToggling(false);
-            toast.error("Error!", {
-              position: "top-right",
+            toast.error('Error!', {
+              position: 'top-right',
               autoClose: 5000,
               hideProgressBar: false,
               closeOnClick: true,
               pauseOnHover: false,
               draggable: true,
-              progress: undefined,
+              progress: undefined
             });
-          },
+          }
         }
       );
     }
@@ -110,7 +110,7 @@ const TemporaryChannelsDashboardPageComponent = ({
   const { mutate: deleteHub } = trpc.hub.delete.useMutation();
   const utils = trpc.useContext();
   const { data, isLoading } = trpc.guild.getGuild.useQuery({
-    id: query as string,
+    id: query as string
   });
 
   const enabled = data?.guild?.hub && data.guild.hubChannel;
@@ -125,8 +125,8 @@ const TemporaryChannelsDashboardPageComponent = ({
       {data?.guild && !isLoading ? (
         <div className="flex flex-col gap-4">
           <h3>
-            The temporary channels feature is {enabled ? "enabled" : "disabled"}
-            , do you want to {enabled ? "disable" : "enable"} it?
+            The temporary channels feature is {enabled ? 'enabled' : 'disabled'}
+            , do you want to {enabled ? 'disable' : 'enable'} it?
           </h3>
           <button
             type="submit"
@@ -136,11 +136,11 @@ const TemporaryChannelsDashboardPageComponent = ({
           >
             {isToggling
               ? enabled
-                ? "Disabling..."
-                : "Enabling..."
+                ? 'Disabling...'
+                : 'Enabling...'
               : enabled
-              ? "Disable"
-              : "Enable"}
+              ? 'Disable'
+              : 'Enable'}
           </button>
         </div>
       ) : (
@@ -163,15 +163,15 @@ export const getServerSideProps: GetServerSideProps = async (
 
   if (!session || !session.user || !session.user.id) {
     return {
-      redirect: { destination: "../../api/auth/signin", permanent: false },
-      props: {},
+      redirect: { destination: '../../api/auth/signin', permanent: false },
+      props: {}
     };
   }
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/pages/dashboard/[guild_id]/welcome.tsx
+++ b/packages/dashboard/src/pages/dashboard/[guild_id]/welcome.tsx
@@ -1,19 +1,19 @@
-import { useRouter } from "next/router";
-import { ReactElement } from "react";
-import DashboardLayout from "../../../components/DashboardLayout";
-import { trpc } from "../../../utils/trpc";
-import { NextPageWithLayout } from "../../_app";
-import { Switch } from "@headlessui/react";
-import WelcomeMessageInput from "../../../components/WelcomeMessageInput";
-import WelcomeMessageChannelPicker from "../../../components/WelcomeMessageChannelPicker";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { getServerSession } from "../../../shared/get-server-session";
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
+import DashboardLayout from '../../../components/DashboardLayout';
+import { trpc } from '../../../utils/trpc';
+import { NextPageWithLayout } from '../../_app';
+import { Switch } from '@headlessui/react';
+import WelcomeMessageInput from '../../../components/WelcomeMessageInput';
+import WelcomeMessageChannelPicker from '../../../components/WelcomeMessageChannelPicker';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { getServerSession } from '../../../shared/get-server-session';
 
 const WelcomeDashboardPage: NextPageWithLayout = () => {
   const router = useRouter();
   const query = router.query.guild_id;
-  if (!query || typeof query !== "string") {
-    router.push("/");
+  if (!query || typeof query !== 'string') {
+    router.push('/');
   }
 
   const { isLoading, error } = trpc.guild.getGuildAndUser.useQuery(
@@ -25,7 +25,7 @@ const WelcomeDashboardPage: NextPageWithLayout = () => {
     return <div>Loading...</div>;
   }
 
-  if (error?.data?.code === "UNAUTHORIZED") {
+  if (error?.data?.code === 'UNAUTHORIZED') {
     return <div>{error.message}</div>;
   }
 
@@ -35,7 +35,7 @@ const WelcomeDashboardPage: NextPageWithLayout = () => {
 const WelcomeDashboardPageComponent = ({ query }: { query: string }) => {
   const utils = trpc.useContext();
   const { data, isLoading } = trpc.guild.getGuild.useQuery({
-    id: query,
+    id: query
   });
 
   const { mutate } = trpc.welcome.toggle.useMutation();
@@ -46,7 +46,7 @@ const WelcomeDashboardPageComponent = ({ query }: { query: string }) => {
       {
         onSuccess: () => {
           utils.guild.getGuild.invalidate();
-        },
+        }
       }
     );
   }
@@ -63,7 +63,7 @@ const WelcomeDashboardPageComponent = ({ query }: { query: string }) => {
           </h3>
           <div className="flex items-center gap-5">
             <span>
-              {data?.guild?.welcomeMessageEnabled ? "Enabled" : "Disabled"}
+              {data?.guild?.welcomeMessageEnabled ? 'Enabled' : 'Disabled'}
             </span>
             <Switch
               checked={data?.guild?.welcomeMessageEnabled}
@@ -72,16 +72,16 @@ const WelcomeDashboardPageComponent = ({ query }: { query: string }) => {
               }
               className={`${
                 data?.guild?.welcomeMessageEnabled
-                  ? "bg-blue-600"
-                  : "bg-gray-400"
+                  ? 'bg-blue-600'
+                  : 'bg-gray-400'
               } relative inline-flex h-6 w-11 items-center rounded-full`}
             >
               <span
                 aria-hidden="true"
                 className={`${
                   data?.guild?.welcomeMessageEnabled
-                    ? "translate-x-6"
-                    : "translate-x-1"
+                    ? 'translate-x-6'
+                    : 'translate-x-1'
                 } inline-block h-4 w-4 transform rounded-full bg-white transition duration-200 ease-in-out`}
               />
             </Switch>
@@ -113,15 +113,15 @@ export const getServerSideProps: GetServerSideProps = async (
 
   if (!session || !session.user || !session.user.id) {
     return {
-      redirect: { destination: "../../api/auth/signin", permanent: false },
-      props: {},
+      redirect: { destination: '../../api/auth/signin', permanent: false },
+      props: {}
     };
   }
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/pages/dashboard/index.tsx
+++ b/packages/dashboard/src/pages/dashboard/index.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps, GetServerSidePropsContext, NextPage } from "next";
-import Head from "next/head";
-import { getServerSession } from "../../shared/get-server-session";
-import { trpc } from "../../utils/trpc";
-import GuildSelectBox from "../../components/GuildSelectBox";
+import { GetServerSideProps, GetServerSidePropsContext, NextPage } from 'next';
+import Head from 'next/head';
+import { getServerSession } from '../../shared/get-server-session';
+import { trpc } from '../../utils/trpc';
+import GuildSelectBox from '../../components/GuildSelectBox';
 
 const DashboardIndexPage: NextPage = () => {
   const { data } = trpc.guild.getAll.useQuery();
@@ -17,9 +17,9 @@ const DashboardIndexPage: NextPage = () => {
         <h1 className="text-3xl mb-4 ml-1">Choose guild to manage</h1>
         {data?.apiGuilds ? (
           <div className="flex gap-10">
-            {data?.apiGuilds.map((guild) => {
+            {data?.apiGuilds.map(guild => {
               const isBotInGuild = data.dbGuilds.some(
-                (dbGuild) => dbGuild.id === guild.id
+                dbGuild => dbGuild.id === guild.id
               );
               return (
                 <GuildSelectBox
@@ -27,7 +27,7 @@ const DashboardIndexPage: NextPage = () => {
                   img={
                     guild.icon
                       ? `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`
-                      : "generic-image.png"
+                      : 'generic-image.png'
                   }
                   name={guild.name}
                   isBotIn={isBotInGuild}
@@ -49,15 +49,15 @@ export const getServerSideProps: GetServerSideProps = async (
 
   if (!session || !session.user || !session.user.id) {
     return {
-      redirect: { destination: "../api/auth/signin", permanent: false },
-      props: {},
+      redirect: { destination: '../api/auth/signin', permanent: false },
+      props: {}
     };
   }
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/pages/index.tsx
+++ b/packages/dashboard/src/pages/index.tsx
@@ -1,12 +1,12 @@
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
-  NextPage,
-} from "next";
-import Head from "next/head";
-import HeaderButton from "../components/HeaderButton";
-import Logo from "../components/Logo";
-import { getServerSession } from "../shared/get-server-session";
+  NextPage
+} from 'next';
+import Head from 'next/head';
+import HeaderButton from '../components/HeaderButton';
+import Logo from '../components/Logo';
+import { getServerSession } from '../shared/get-server-session';
 
 const HomeComponent = () => {
   return (
@@ -49,8 +49,8 @@ export const getServerSideProps: GetServerSideProps = async (
 
   return {
     props: {
-      session,
-    },
+      session
+    }
   };
 };
 

--- a/packages/dashboard/src/shared/get-server-session.ts
+++ b/packages/dashboard/src/shared/get-server-session.ts
@@ -1,10 +1,10 @@
-import { GetServerSidePropsContext } from "next";
-import { unstable_getServerSession } from "next-auth";
-import { authOptions as nextAuthOptions } from "../pages/api/auth/[...nextauth]";
+import { GetServerSidePropsContext } from 'next';
+import { unstable_getServerSession } from 'next-auth';
+import { authOptions as nextAuthOptions } from '../pages/api/auth/[...nextauth]';
 
 export const getServerSession = async (ctx: {
-  req: GetServerSidePropsContext["req"];
-  res: GetServerSidePropsContext["res"];
+  req: GetServerSidePropsContext['req'];
+  res: GetServerSidePropsContext['res'];
 }) => {
   return await unstable_getServerSession(ctx.req, ctx.res, nextAuthOptions);
 };

--- a/packages/dashboard/src/types/next-auth.d.ts
+++ b/packages/dashboard/src/types/next-auth.d.ts
@@ -1,12 +1,12 @@
-import { DefaultSession } from "next-auth";
+import { DefaultSession } from 'next-auth';
 
-declare module "next-auth" {
+declare module 'next-auth' {
   /**
    * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
    */
   interface Session {
     user?: {
       id: string;
-    } & DefaultSession["user"];
+    } & DefaultSession['user'];
   }
 }

--- a/packages/dashboard/src/utils/trpc.ts
+++ b/packages/dashboard/src/utils/trpc.ts
@@ -1,1 +1,1 @@
-export * from "@master-bot/react/trpc";
+export * from '@master-bot/react/trpc';

--- a/packages/dashboard/tailwind.config.cjs
+++ b/packages/dashboard/tailwind.config.cjs
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {}
   },
-  plugins: [],
+  plugins: []
 };

--- a/packages/node/trpc.ts
+++ b/packages/node/trpc.ts
@@ -1,12 +1,12 @@
-import type { AppRouter } from "@master-bot/api/src/routers/index";
-import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
-import superjson from "superjson";
+import type { AppRouter } from '@master-bot/api/src/routers/index';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
 
 export const trpcNode = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     httpBatchLink({
-      url: "http://localhost:3000/api/trpc",
-    }),
-  ],
+      url: 'http://localhost:3000/api/trpc'
+    })
+  ]
 });

--- a/packages/react/trpc.tsx
+++ b/packages/react/trpc.tsx
@@ -1,26 +1,26 @@
 // src/utils/trpc.ts
-import type { AppRouter } from "@master-bot/api/src/routers/index";
-import { httpBatchLink } from "@trpc/client";
-import { createTRPCNext } from "@trpc/next";
-import superjson from "superjson";
+import type { AppRouter } from '@master-bot/api/src/routers/index';
+import { httpBatchLink } from '@trpc/client';
+import { createTRPCNext } from '@trpc/next';
+import superjson from 'superjson';
 
 export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       // during client requests
       return {
         transformer: superjson, // optional - adds superjson serialization
         links: [
           httpBatchLink({
-            url: "/api/trpc",
-          }),
-        ],
+            url: '/api/trpc'
+          })
+        ]
       };
     }
     // The server needs to know your app's full url
     const url = process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}/api/trpc`
-      : "http://localhost:3000/api/trpc";
+      : 'http://localhost:3000/api/trpc';
     return {
       transformer: superjson, // optional - adds superjson serialization
       links: [
@@ -41,16 +41,16 @@ export const trpc = createTRPCNext<AppRouter>({
                 ...headers
               } = ctx.req.headers;
               return {
-                ...headers,
+                ...headers
                 // Optional: inform server that it's an SSR request
                 //"x-ssr": "1",
               };
             }
             return {};
-          },
-        }),
-      ],
+          }
+        })
+      ]
     };
   },
-  ssr: false,
+  ssr: false
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,8 @@ model User {
   sessions      Session[]
   playlists     Playlist[]
   guilds        Guild[]
+  reminders     Reminder[]
+  timeOffset    Int?
 }
 
 model VerificationToken {
@@ -116,4 +118,16 @@ model TwitchNotify {
   live       Boolean  @default(false)
   channelIds String[]
   sent       Boolean
+}
+
+model Reminder {
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now())
+  repeat      String?
+  event       String
+  description String?
+  dateTime    String
+  userId      String
+  user        User?    @relation(fields: [userId], references: [discordId])
+  timeOffset  Int
 }


### PR DESCRIPTION
a Repost of #753 move to TRPC v10

## Function
when bot is started, the reminders Table from Postgres is cached to redis and refreshed once a day (also checks for stale reminders that may still be in the Postgres DB due to a possible missed trigger event and either remove them or set up for the next alarm)
uses Redis TTL and a keyspace event listener to trigger the notifications.
uses Direct Messages to function, and was designed to be personal reminders, so most of the responses are ephemeral.
You can set reminders by Text Channel or Direct Message. 
All reminders are Direct Messages (can't annoy other people)
if it had a repeat options, then create a new db entry when message is sent (or during clean up check at start up or daily check)

## Caveat
- Doesn't account for Daylight Savings Time (just resave your timeOffset with `/reminder save-timezone`)

## Objectives
- [x]  Convert to Redis TTL
- [x]  Update to TRPC v10
- [x]  Sub Commands View/Set/Remove/Save-timezone
- [x]  Small input chain - Minimum of 2 Inputs to set a reminder `event` and `time`
- [x] TimeZones - Get users Timezone offset by asking for Local Date and Time
- [x] Repeat options - "daily", "weekly", "yearly", "monthly*"
- [x] Compatible with Pi (arm64) 
- [x] Compatible in dockerized containers (need additional `.env` variable `TZ=<tz-database-name>` when using Docker Only)
- [x] DB maintenance - Checks (at launch and every 24 hours) and remove stale/old Reminders from Postgres, if reminder had a repeat option selected, then recreate reminder for the need time

*Monthly option can only be used if the desired Day is less than the 28th

Much Love
-Bacon