### PR TITLE
Patch - Commands not working in DM

### DIFF
--- a/packages/bot/src/preconditions/IsCommandDisabled.ts
+++ b/packages/bot/src/preconditions/IsCommandDisabled.ts
@@ -16,7 +16,10 @@ export class IsCommandDisabled extends Precondition {
   ): AsyncPreconditionResult {
     const commandID = interaction.commandId;
     const guildID = interaction.guildId as string;
-
+    // Most likly a DM
+    if (!interaction.guildId && interaction.user.id) {
+      return this.ok();
+    }
     const data = await trpcNode.command.getDisabledCommands.query({
       guildId: guildID
     });


### PR DESCRIPTION
Added the following to `IsCommandDisabled.ts` before the `const data` trcp query
```
    if (!interaction.guildId && interaction.user.id) {
      return this.ok();
    }
```
##### Testing
- [x] Allows commands to work in DMs
- [x] still able to enable/disable commands per guild
- [x] /play and other guild only commands provide a message informing the user that the command is guild only


Much Love
-Bacon