### PR TITLE
Docker compose for turbo rewrite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,4 @@ node_modules
 dist
 logs
 Lavalink.jar
+.turbo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,31 @@
 FROM node:19-slim
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR "/Master-Bot"
-
-# Install prerequisites and register fonts
-RUN apt-get update && apt-get install -y -q openssl && apt-get install -y -q && apt-get install -y -q --no-install-recommends libfontconfig1 && npm install -g pnpm
-
-# Copy files to Container (Excluding whats in .dockerignore)
-COPY ./ ./
-
-# Install for Docker-Compose (Excluding "postinstall")
-RUN pnpm install --ignore-scripts
-RUN pnpm exec turbo db:generate -- schema ./packages/db/prisma/schema.prisma
-
-# Install for Standalone Dockerfile use (comment out the 2 lines above and uncomment the line below)
-# RUN pnpm install
 
 # Ports for the Dashboard  
 EXPOSE 3000
 ENV PORT 3000
 
-# Stop Nextjs Data Collection
-ENV NEXT_TELEMETRY_DISABLED 1
+# Install prerequisites and register fonts
+RUN apt-get update && apt-get install -y -q openssl && \
+    apt-get install -y -q && \
+    apt-get install -y -q --no-install-recommends libfontconfig1 && \ 
+    npm install -g pnpm
 
-# Run Concurrent Start Script
-# CMD ["pnpm", "run", "dev-parallel"]
+# Copy files to Container (Excluding whats in .dockerignore)
+COPY ./ ./
+
+# Docker-Compose Container Cluster Build
+RUN pnpm install --ignore-scripts
+
+# If you are running Master-Bot in a Standalone Container and need to connect to a service on localhost uncomment the following ENV for each service running on the containers host
+# ENV POSTGRES_HOST="host.docker.internal"
+# ENV REDIS_HOST="host.docker.internal"
+# ENV LAVA_HOST="host.docker.internal"
+
+# Uncomment the following for Standalone Master-Bot Docker Container Build
+# RUN pnpm db:push
+
+CMD ["pnpm", "run", "dev-parallel"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:19-slim
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+WORKDIR "/Master-Bot"
+
+# Install prerequisites and register fonts
+RUN apt-get update && apt-get install -y -q openssl && apt-get install -y -q && apt-get install -y -q --no-install-recommends libfontconfig1 && npm install -g pnpm
+
+# Copy files to Container (Excluding whats in .dockerignore)
+COPY ./ ./
+
+# Install for Docker-Compose (Excluding "postinstall")
+RUN pnpm install --ignore-scripts
+RUN pnpm exec turbo db:generate -- schema ./packages/db/prisma/schema.prisma
+
+# Install for Standalone Dockerfile use (comment out the 2 lines above and uncomment the line below)
+# RUN pnpm install
+
+# Ports for the Dashboard  
+EXPOSE 3000
+ENV PORT 3000
+
+# Stop Nextjs Data Collection
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Run Concurrent Start Script
+# CMD ["pnpm", "run", "dev-parallel"]

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"build": "pnpm with-env tsc",
 		"watch": "tsc --watch",
-		"copy-scripts": "pnpx ncp ./scripts ./dist/",
+		"copy-scripts": "pnpm exec ncp ./scripts ./dist/",
 		"dev": "pnpm build && pnpm copy-scripts && run-p watch start",
 		"start": "pnpm with-env node dist/index.js",
 		"with-env": "dotenv -e ../../.env --"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,15 @@ services:
       - redis
       - postgres
     volumes:
-      - ./logs:/Master-Bot/packages/bot/logs
+      - ./logs:/Master-Bot/apps/bot/logs
   lavalink:
     restart: always
-    image: fredboat/lavalink:3.7.8-alpine
+    image: fredboat/lavalink:3-alpine
     healthcheck:
       test: 'echo lavalink'
+      interval: 10s
+      timeout: 10s
+      retries: 3
     volumes:
       - ./application.yml:/opt/Lavalink/application.yml
   postgres:
@@ -59,7 +62,7 @@ services:
   redis:
     env_file:
       - docker.env
-    image: redis:alpine
+    image: redis:7-alpine
     restart: always
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+services:
+  master-bot:
+    env_file:
+      - docker.env
+    restart: always
+    build: .
+    ports:
+      - '3000:3000' # Dashboard
+      # - "5555:5555" # Prisma Studio Port  - uncomment to open
+    command: >
+      sh -c "pnpm run db:push && pnpm run dev-parallel"
+    depends_on:
+      lavalink:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Password is required and must match '.env' file
+      POSTGRES_DB_NAME: ${POSTGRES_DB_NAME} # Must match '.env' file
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST} # Must match '.env' file
+      REDIS_HOST: ${REDIS_HOST} # Must match service name
+      REDIS_PORT: ${REDIS_PORT}
+      REDIS_DB: ${REDIS_DB}
+    links:
+      - lavalink
+      - redis
+      - postgres
+    volumes:
+      - ./logs:/Master-Bot/packages/bot/logs
+  lavalink:
+    restart: always
+    image: fredboat/lavalink:3.7.8-alpine
+    healthcheck:
+      test: 'echo lavalink'
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+  postgres:
+    env_file:
+      - docker.env
+    image: postgres:15-alpine
+    restart: always
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB_NAME}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB_NAME=${POSTGRES_DB_NAME}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  redis:
+    env_file:
+      - docker.env
+    image: redis:alpine
+    restart: always
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_DB=${REDIS_DB}
+    command: redis-server --save 20 1 --loglevel warning
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - redis:/data
+volumes:
+  postgres:
+    driver: local
+  redis:
+    driver: local

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,26 @@
+ # Editing this file is not required and used for Docker-Compose Only
+ # these will overwrite the needed .env variables to create and link ALL the containers correctly
+ # Fill out your .env as normal then to dockerize   
+ # run "docker compose --env-file docker.env up -d --build" in root folder
+ 
+ # Prisma Override
+ DATABASE_URL="postgresql://postgresUsername:postgresPassword@postgres:5432/master-bot?schema=public&connect_timeout=300"
+
+ # LavaLink Docker Container
+ LAVA_HOST="lavalink"
+ LAVA_PASS="youshallnotpass"
+ LAVA_PORT=2333
+ LAVA_SECURE=false
+
+ # Postgres Docker Container
+ POSTGRES_HOST="postgres" 
+ POSTGRES_USER="postgresUsername"
+ POSTGRES_PORT=5432
+ POSTGRES_PASSWORD="postgresPassword"
+ POSTGRES_DB_NAME="master-bot"
+
+ # Redis Docker Container
+ REDIS_HOST="redis" 
+ REDIS_PORT=6379
+ REDIS_DB=0
+ REDIS_PASSWORD="redisPassword"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"lint": "turbo lint && manypkg check",
 		"lint:fix": "turbo lint:fix && manypkg fix",
 		"type-check": "turbo type-check",
-		"postinstall": "pnpm db:push"
+		"postinstall": "pnpm db:push",
+		"docker-compose": "docker compose --env-file docker.env up -d --build"
 	},
 	"dependencies": {
 		"@ianvs/prettier-plugin-sort-imports": "^4.1.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
 		"db:generate": "pnpm with-env prisma generate",
 		"db:push": "pnpm with-env prisma db push --skip-generate",
 		"db:reset": "pnpm with-env prisma db push --force-reset",
+		"dev": "pnpm with-env prisma studio",
 		"with-env": "dotenv -e ../../.env --"
 	},
 	"dependencies": {


### PR DESCRIPTION
docker implementation for turbo rewrite

users can run `pnpm run docker-compose` to build/update the docker cluster

Change summary
Dockerfile - revised for pnpm and nodejs v19-slim
docker-compose - specified a major version for each service in cluster (redis, postgres, lavalink)
.dockerignore - added ".turbo" folders to the list
package.json - added "docker-compose" script 

Minor package.json script changes
`packages\db\package.json` - added the missing "dev" script when trying to use `pnpm run db:studio`
`apps\bot\package.json` -  "copy-scripts" changed the `pnpx` -> `pnpm exec` - `pnpx` seems to have been deprecated and `pnpm exec` and `pnpm dlx` can be used with pnpm@8.6.7 or higher

Much Love
-Bacon
