### PR TITLE
Revised Docker Implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM --platform=linux/amd64 node:18-slim
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+ENV NEXT_TELEMETRY_DISABLED 1
+WORKDIR "/Master-Bot"
+
+# Ports for the Dashboard  
+EXPOSE 3000
+ENV PORT 3000
+
+# Install prerequisites and register fonts
+RUN apt-get update && apt-get upgrade -y -q && \
+    apt-get install -y -q openssl && \
+    apt-get install -y -q --no-install-recommends libfontconfig1 && \ 
+    npm install -g pnpm 
+
+# Copy files to Container (Excluding whats in .dockerignore)
+COPY ./ ./
+RUN pnpm install --ignore-scripts && pnpm -F * build 
+
+# If you are running Master-Bot in a Standalone Container and need to connect to a service on localhost uncomment the following ENV for each service running on the containers host
+# ENV POSTGRES_HOST="host.docker.internal"
+# ENV REDIS_HOST="host.docker.internal"
+# ENV LAVA_HOST="host.docker.internal"
+
+# Uncomment the following for Standalone Master-Bot Docker Container Build
+# RUN pnpm db:push
+# CMD ["pnpm", "-r", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,85 @@
+version: '3'
+services:
+  master-bot:
+    platform: 'linux/amd64'
+    env_file:
+      - docker.env
+    restart: always
+    build: .
+    ports:
+      - '3000:3000' # Dashboard
+      # - "5555:5555" # Prisma Studio Port  - uncomment to open
+    command: >
+      sh -c "pnpm run db:push && pnpm run -r start"
+    depends_on:
+      lavalink:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Password is required and must match '.env' file
+      POSTGRES_DB_NAME: ${POSTGRES_DB_NAME} # Must match '.env' file
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST} # Must match '.env' file
+      REDIS_HOST: ${REDIS_HOST} # Must match service name
+      REDIS_PORT: ${REDIS_PORT}
+      REDIS_DB: ${REDIS_DB}
+    links:
+      - lavalink
+      - redis
+      - postgres
+    volumes:
+      - ./logs:/Master-Bot/apps/bot/logs
+  lavalink:
+    restart: always
+    image: fredboat/lavalink:3-alpine
+    healthcheck:
+      test: 'echo lavalink'
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+  postgres:
+    env_file:
+      - docker.env
+    image: postgres:15-alpine
+    restart: always
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB_NAME}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB_NAME=${POSTGRES_DB_NAME}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  redis:
+    env_file:
+      - docker.env
+    image: redis:7-alpine
+    restart: always
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_DB=${REDIS_DB}
+    command: redis-server --save 20 1 --loglevel warning
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - redis:/data
+volumes:
+  postgres:
+    driver: local
+  redis:
+    driver: local

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,26 @@
+ # Editing this file is not required and used for Docker-Compose Only
+ # these will overwrite the needed .env variables to create and link ALL the containers correctly
+ # Fill out your .env as normal then to dockerize   
+ # run "docker compose --env-file docker.env up -d --build" in root folder
+ 
+ # Prisma Override
+ DATABASE_URL="postgresql://postgresUsername:postgresPassword@postgres:5432/master-bot?schema=public&connect_timeout=300"
+
+ # LavaLink Docker Container
+ LAVA_HOST="lavalink"
+ LAVA_PASS="youshallnotpass"
+ LAVA_PORT=2333
+ LAVA_SECURE=false
+
+ # Postgres Docker Container
+ POSTGRES_HOST="postgres" 
+ POSTGRES_USER="postgresUsername"
+ POSTGRES_PORT=5432
+ POSTGRES_PASSWORD="postgresPassword"
+ POSTGRES_DB_NAME="master-bot"
+
+ # Redis Docker Container
+ REDIS_HOST="redis" 
+ REDIS_PORT=6379
+ REDIS_DB=0
+ REDIS_PASSWORD="redisPassword"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"lint": "turbo lint && manypkg check",
 		"lint:fix": "turbo lint:fix && manypkg fix",
 		"type-check": "turbo type-check",
-		"postinstall": "pnpm db:push"
+		"postinstall": "pnpm db:push",
+		"docker-compose": "docker compose --env-file docker.env up -d --build"
 	},
 	"dependencies": {
 		"@ianvs/prettier-plugin-sort-imports": "^4.1.0",


### PR DESCRIPTION
Trying to make it a little easier to get everything needed to get up and running by bundling all the services inside a docker cluster

Requires Docker with Docker Compose v3+ **_or_** Docker Desktop
need a completed `.env` and `application.yml` in `./Master-Bot/` folder
run `npm run docker-compose` (or with `pnpm`)
this will build Redis, Postgres, Lavalink, and Master-Bot containers inside a docker cluster.

Unfortunately, users that are currently running the older implementation may run into a `incompatibility error` with Postgres and will need to remove the older docker cluster and delete the old DB volumes 

changes from previous release
- defined major version numbers for bundled services (Redis 7.x, Postgres 15.x, Lavalink 3.x)
- `master-bot-1` container uses `pnpm` instead of `npm`
- `master-bot-1` container no longer runs with dev tools, speeds up the Bot and Dashboard response time right after being built/started


Much Love
-Bacon

